### PR TITLE
OLMIS-8020: Fix initiating requisitions with stocks on hand populated from stock cards

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,13 +183,13 @@ configure(checkApiIsRaml) {
 jacocoTestReport {
     group = "reporting"
     description = "Generate Jacoco coverage reports after running tests."
+    executionData integrationTest
     reports {
         xml.enabled true
         html.enabled true
         csv.enabled false
     }
-
-    additionalSourceDirs(files(sourceSets.main.allJava.srcDirs))
+    dependsOn test, integrationTest
 }
 
 checkstyle {

--- a/src/integration-test/java/org/openlmis/stockmanagement/service/StockCardServiceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/service/StockCardServiceIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -122,6 +123,9 @@ public class StockCardServiceIntegrationTest extends BaseIntegrationTest {
   @MockBean
   private PermissionService permissionService;
 
+  @MockBean
+  private HomeFacilityPermissionService homeFacilityPermissionService;
+
   private Node node;
 
   private StockCardLineItemReason reason;
@@ -142,6 +146,9 @@ public class StockCardServiceIntegrationTest extends BaseIntegrationTest {
     reason = new StockCardLineItemReason("reason", null, ReasonType.CREDIT,
         ReasonCategory.ADJUSTMENT, false, Collections.emptyList());
     stockCardLineItemReasonRepository.save(reason);
+
+    when(homeFacilityPermissionService.checkFacilityAndHomeFacilityLinkage(any(UUID.class)))
+            .thenReturn(false);
   }
 
   @After

--- a/src/main/java/org/openlmis/stockmanagement/service/StockCardService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockCardService.java
@@ -149,9 +149,15 @@ public class StockCardService extends StockCardBaseService {
       return null;
     }
     StockCard foundCard = card.shallowCopy();
+    OAuth2Authentication authentication =
+        (OAuth2Authentication) SecurityContextHolder.getContext().getAuthentication();
 
     LOGGER.debug("Stock card found");
-    permissionService.canViewStockCard(foundCard.getProgramId(), foundCard.getFacilityId());
+
+    if (!authentication.isClientOnly() && !homeFacilityPermissionService
+        .checkFacilityAndHomeFacilityLinkage(foundCard.getFacilityId())) {
+      permissionService.canViewStockCard(foundCard.getProgramId(), foundCard.getFacilityId());
+    }
 
     calculationSoHService.calculateStockOnHand(foundCard);
 

--- a/src/main/java/org/openlmis/stockmanagement/service/StockCardService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockCardService.java
@@ -105,6 +105,9 @@ public class StockCardService extends StockCardBaseService {
   @Autowired
   private StockOnHandCalculationService calculationSoHService;
 
+  @Autowired
+  private HomeFacilityPermissionService homeFacilityPermissionService;
+
   /**
    * Generate stock card line items and stock cards based on event, and persist them.
    *

--- a/src/main/java/org/openlmis/stockmanagement/service/StockCardSummariesService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockCardSummariesService.java
@@ -63,6 +63,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.stereotype.Service;
 
 /**
@@ -145,8 +147,10 @@ public class StockCardSummariesService extends StockCardBaseService {
   public StockCardSummaries findStockCards(StockCardSummariesV2SearchParams params) {
     Profiler profiler = new Profiler("FIND_STOCK_CARD_SUMMARIES_FOR_PARAMS");
     profiler.setLogger(LOGGER);
+    OAuth2Authentication authentication =
+        (OAuth2Authentication) SecurityContextHolder.getContext().getAuthentication();
 
-    if (!homeFacilityPermissionService
+    if (!authentication.isClientOnly() && !homeFacilityPermissionService
         .checkFacilityAndHomeFacilityLinkage(params.getFacilityId())) {
       profiler.start("VALIDATE_VIEW_RIGHTS");
       permissionService.canViewStockCard(params.getProgramId(), params.getFacilityId());

--- a/src/test/java/org/openlmis/stockmanagement/service/StockCardSummariesServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockCardSummariesServiceTest.java
@@ -33,7 +33,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -292,8 +291,6 @@ public class StockCardSummariesServiceTest {
     StockCardSummaries result = stockCardSummariesService.findStockCards(params);
 
     assertEquals(3, result.getPageOfApprovedProducts().size());
-    verify(permissionService, times(params.getProgramIds().size()))
-        .canViewStockCard(any(UUID.class), any(UUID.class));
   }
 
   @Test
@@ -313,7 +310,7 @@ public class StockCardSummariesServiceTest {
     when(approvedProductReferenceDataService
         .getApprovedProducts(
             eq(params.getFacilityId()),
-            eq(params.getProgramIds()),
+            eq(params.getProgramId()),
             eq(params.getOrderableIds()),
             eq(params.getOrderableCode()),
             eq(params.getOrderableName())
@@ -340,7 +337,7 @@ public class StockCardSummariesServiceTest {
 
     StockEvent event = new StockEventDataBuilder()
         .withFacility(params.getFacilityId())
-        .withProgram(params.getProgramIds().get(0))
+        .withProgram(params.getProgramId())
         .build();
 
     StockCard stockCard = new StockCardDataBuilder(event)
@@ -351,7 +348,7 @@ public class StockCardSummariesServiceTest {
     List<StockCard> stockCards = singletonList(stockCard);
 
     when(calculatedStockOnHandService
-        .getStockCardsWithStockOnHand(params.getProgramIds(), params.getFacilityId(),
+        .getStockCardsWithStockOnHand(params.getProgramId(), params.getFacilityId(),
             params.getAsOfDate(), Collections.emptyList(), Collections.emptySet()))
         .thenReturn(stockCards);
 

--- a/src/test/java/org/openlmis/stockmanagement/service/StockCardSummariesServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockCardSummariesServiceTest.java
@@ -32,6 +32,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
@@ -46,6 +49,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -82,6 +87,9 @@ import org.slf4j.profiler.Profiler;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
 
 @SuppressWarnings("PMD.TooManyMethods")
 @RunWith(MockitoJUnitRunner.class)
@@ -125,6 +133,18 @@ public class StockCardSummariesServiceTest {
   private HomeFacilityPermissionService homeFacilityPermissionService;
   @InjectMocks
   private StockCardSummariesService stockCardSummariesService;
+
+  @Mock
+  private SecurityContext securityContext;
+  @Mock
+  private OAuth2Authentication authentication;
+
+  @Before
+  public void setUp() {
+    SecurityContextHolder.setContext(securityContext);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    when(authentication.isClientOnly()).thenReturn(false);
+  }
 
   @Test
   public void shouldCreateDummyCards() {
@@ -272,6 +292,74 @@ public class StockCardSummariesServiceTest {
     StockCardSummaries result = stockCardSummariesService.findStockCards(params);
 
     assertEquals(3, result.getPageOfApprovedProducts().size());
+    verify(permissionService, times(params.getProgramIds().size()))
+        .canViewStockCard(any(UUID.class), any(UUID.class));
+  }
+
+  @Test
+  public void shouldNotCallPermissionServiceWhenApplicationClientOnly() {
+    OrderableDto orderable = new OrderableDtoDataBuilder().build();
+    OrderableDto orderable2 = new OrderableDtoDataBuilder().build();
+
+    OrderablesAggregator orderablesAggregator = new OrderablesAggregator(asList(
+        new ApprovedProductDto(orderable),
+        new ApprovedProductDto(orderable2)
+    ));
+
+    StockCardSummariesV2SearchParams params = new StockCardSummariesV2SearchParamsDataBuilder()
+        .withOrderableIds(asList(orderable.getId(), orderable2.getId()))
+        .build();
+
+    when(approvedProductReferenceDataService
+        .getApprovedProducts(
+            eq(params.getFacilityId()),
+            eq(params.getProgramIds()),
+            eq(params.getOrderableIds()),
+            eq(params.getOrderableCode()),
+            eq(params.getOrderableName())
+        ))
+        .thenReturn(orderablesAggregator);
+
+    Map<UUID, OrderableFulfillDto> fulfillMap = new HashMap<>();
+    fulfillMap.put(orderable.getId(), new OrderableFulfillDtoDataBuilder()
+        .withCanFulfillForMe(singletonList(orderable2.getId())).build());
+    fulfillMap.put(orderable2.getId(), new OrderableFulfillDtoDataBuilder()
+        .withCanFulfillForMe(singletonList(orderable.getId())).build());
+
+    when(orderableFulfillReferenceDataService
+        .findByIds(asList(orderable.getId(), orderable2.getId())))
+        .thenReturn(fulfillMap);
+
+    when(lotReferenceDataService.getPage(any(RequestParameters.class)))
+        .thenReturn(new PageImpl<>(Collections.emptyList()));
+
+    when(orderableReferenceDataService.getPage(any(RequestParameters.class)))
+        .thenReturn(new PageImpl<>(Collections.emptyList()));
+
+    when(authentication.isClientOnly()).thenReturn(true);
+
+    StockEvent event = new StockEventDataBuilder()
+        .withFacility(params.getFacilityId())
+        .withProgram(params.getProgramIds().get(0))
+        .build();
+
+    StockCard stockCard = new StockCardDataBuilder(event)
+        .withOrderableId(orderable.getId())
+        .withStockOnHand(12)
+        .build();
+
+    List<StockCard> stockCards = singletonList(stockCard);
+
+    when(calculatedStockOnHandService
+        .getStockCardsWithStockOnHand(params.getProgramIds(), params.getFacilityId(),
+            params.getAsOfDate(), Collections.emptyList(), Collections.emptySet()))
+        .thenReturn(stockCards);
+
+    StockCardSummaries result = stockCardSummariesService.findStockCards(params);
+
+    assertEquals(2, result.getPageOfApprovedProducts().size());
+    verify(permissionService, never())
+        .canViewStockCard(any(UUID.class), any(UUID.class));
   }
 
   @Test(expected = PermissionMessageException.class)


### PR DESCRIPTION
Cherry-picked changes from OAM-269, fixed errors. 