### PR TITLE
OLMIS-8071: When endDate is taken from period, it must be converted to exclusive limit

### DIFF
--- a/src/main/java/org/openlmis/stockmanagement/service/StockCardAggregate.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockCardAggregate.java
@@ -223,8 +223,9 @@ public class StockCardAggregate {
     }
 
     if (null != stockOutStartDate) {
-      LOGGER.debug("stock out days from {} to {}", null == endDate ? LocalDate.now() : endDate);
-      stockOutDaysMap.put(stockOutStartDate, null == endDate ? LocalDate.now() : endDate);
+      // Converts inclusiveEndDate to exclusiveEndDate
+      stockOutDaysMap.put(stockOutStartDate,
+          null == endDate ? LocalDate.now().plusDays(1) : endDate.plusDays(1));
     }
 
     return stockOutDaysMap;

--- a/src/test/java/org/openlmis/stockmanagement/service/StockCardAggregateTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockCardAggregateTest.java
@@ -165,6 +165,26 @@ public class StockCardAggregateTest {
             .withStockCard(stockCard6)
             .withOccurredDate(LocalDate.of(2018, 12, 15))
             .withStockOnHand(0)
+            .build(),
+        new CalculatedStockOnHandDataBuilder()
+            .withStockCard(stockCard6)
+            .withOccurredDate(LocalDate.of(2024, 1, 13))
+            .withStockOnHand(100)
+            .build(),
+        new CalculatedStockOnHandDataBuilder()
+            .withStockCard(stockCard6)
+            .withOccurredDate(LocalDate.of(2024, 1, 19))
+            .withStockOnHand(0)
+            .build(),
+        new CalculatedStockOnHandDataBuilder()
+            .withStockCard(stockCard6)
+            .withOccurredDate(LocalDate.of(2024, 4, 13))
+            .withStockOnHand(100)
+            .build(),
+        new CalculatedStockOnHandDataBuilder()
+            .withStockCard(stockCard6)
+            .withOccurredDate(LocalDate.of(2024, 4, 19))
+            .withStockOnHand(0)
             .build()
     ));
 
@@ -261,6 +281,13 @@ public class StockCardAggregateTest {
         LocalDate.of(2020, 2, 1), LocalDate.of(2020, 2, 29)));
     assertEquals(new Long(60), stockCardAggregate.getStockoutDays(
         LocalDate.of(2020, 7, 1), LocalDate.of(2020, 8, 31)));
+
+    // Received at 13th - 13th the first day with stock, Issued at 19th - 18th the last day with
+    // stock. [1st,13th) = 12 day of stock out, [19th, 1st) = 12
+    assertEquals(new Long(24), stockCardAggregate.getStockoutDays(
+            LocalDate.of(2024, 4, 1), LocalDate.of(2024, 4, 30)));
+    assertEquals(new Long(24), stockCardAggregate.getStockoutDays(
+            LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31)));
   }
 
   @Test
@@ -274,7 +301,7 @@ public class StockCardAggregateTest {
         .build());
 
     // calculated stockout days from first stockCard 2018-05-10 to the last one 2019-11-15
-    long stockoutDaysBeforeDate = 467;
+    long stockoutDaysBeforeDate = 456;
 
     assertEquals(
         new Long(stockoutDaysBeforeDate + Year360Utils.getDaysBetweenUs(date, LocalDate.now())),


### PR DESCRIPTION
For example, April period ends at 30.04, exclusive limit is therefore 1.05.