### PR TITLE
OLMIS-8206: Recalculate stock on hand in place

### DIFF
--- a/src/integration-test/java/org/openlmis/stockmanagement/service/CalculatedStockOnHandServiceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/service/CalculatedStockOnHandServiceIntegrationTest.java
@@ -412,16 +412,11 @@ public class CalculatedStockOnHandServiceIntegrationTest extends BaseIntegration
     stockCard.setLineItems(lineItemlist);
     stockCardRepository.save(stockCard);
 
+    // A row already exists for the day; recalculation updates it in place, never duplicates.
     calculatedStockOnHandRepository.save(
         calculatedStockOnHandDataBuilder
             .withOccurredDate(lineItem.getOccurredDate().plusDays(1))
             .withStockOnHand(10)
-            .build());
-
-    calculatedStockOnHandRepository.save(
-        calculatedStockOnHandDataBuilder
-            .withOccurredDate(lineItem.getOccurredDate().plusDays(1))
-            .withStockOnHand(20)
             .build());
 
     calculatedStockOnHandService.recalculateStockOnHand(Collections.singletonList(lineItem));
@@ -431,6 +426,10 @@ public class CalculatedStockOnHandServiceIntegrationTest extends BaseIntegration
             stockCard.getId(),
             lineItem.getOccurredDate());
 
+    // the day must still have exactly one row (updated in place, not duplicated)
+    assertThat(result.stream()
+        .filter(soh -> soh.getOccurredDate().equals(lineItem.getOccurredDate().plusDays(1)))
+        .count(), is(1L));
     assertThat(result.get(0).getStockOnHand(), is(15));
     assertThat(result.get(1).getStockOnHand(), is(35));
   }

--- a/src/integration-test/java/org/openlmis/stockmanagement/service/StockCardServiceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/service/StockCardServiceIntegrationTest.java
@@ -29,8 +29,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openlmis.stockmanagement.testutils.StockEventDtoDataBuilder.createStockEventDto;
 
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -42,7 +40,6 @@ import org.junit.runner.RunWith;
 import org.openlmis.stockmanagement.BaseIntegrationTest;
 import org.openlmis.stockmanagement.domain.card.StockCard;
 import org.openlmis.stockmanagement.domain.card.StockCardLineItem;
-import org.openlmis.stockmanagement.domain.event.CalculatedStockOnHand;
 import org.openlmis.stockmanagement.domain.event.StockEvent;
 import org.openlmis.stockmanagement.domain.reason.ReasonCategory;
 import org.openlmis.stockmanagement.domain.reason.ReasonType;
@@ -380,14 +377,9 @@ public class StockCardServiceIntegrationTest extends BaseIntegrationTest {
 
     StockEvent event = eventDto.toEvent();
     StockEvent savedEvent = stockEventsRepository.save(event);
+    // saveFromEvent already creates the row for this (stockCard, occurredDate); no second insert.
     stockCardService.saveFromEvent(eventDto, savedEvent.getId());
 
-    List<StockCard> stockCards = stockCardRepository
-        .findByProgramIdAndFacilityId(savedEvent.getProgramId(), savedEvent.getFacilityId());
-    
-    calculatedStockOnHandRepository.save(new CalculatedStockOnHand(
-        savedEvent.getLineItems().get(0).getQuantity(), stockCards.get(0), 
-        LocalDate.now(), ZonedDateTime.now()));
     return savedEvent;
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/repository/CalculatedStockOnHandRepository.java
+++ b/src/main/java/org/openlmis/stockmanagement/repository/CalculatedStockOnHandRepository.java
@@ -32,9 +32,6 @@ public interface CalculatedStockOnHandRepository
           @Param("stockCardId") UUID stockCardId,
           @Param("asOfDate") LocalDate asOfDate);
 
-  Optional<CalculatedStockOnHand> findFirstByStockCardIdAndOccurredDate(
-          UUID stockCardId, LocalDate occurredDate);
-
   List<CalculatedStockOnHand>
       findByStockCardIdAndOccurredDateGreaterThanEqualOrderByOccurredDateAsc(
           UUID stockCardId, LocalDate asOfDate);

--- a/src/main/java/org/openlmis/stockmanagement/service/CalculatedStockOnHandService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/CalculatedStockOnHandService.java
@@ -192,13 +192,14 @@ public class CalculatedStockOnHandService {
     profiler.start("GET_LINE_ITEMS_PREVIOUS_STOCK_ON_HAND");
     int lineItemsPreviousStockOnHand = getPreviousStockOnHand(stockCard, lineItem);
 
+    // Update following entries in place instead of delete + re-insert, which caused the deadlock.
     profiler.start("GET_FOLLOWING_CALCULATED_STOCK_ON_HANDS");
-    List<CalculatedStockOnHand> followingStockOnHands = calculatedStockOnHandRepository
+    Map<LocalDate, CalculatedStockOnHand> existingByDate = calculatedStockOnHandRepository
         .findByStockCardIdAndOccurredDateGreaterThanEqualOrderByOccurredDateAsc(
-            stockCard.getId(), lineItem.getOccurredDate());
-
-    profiler.start("DELETE_FOLLOWING_CALCULATED_STOCK_ON_HANDS");
-    calculatedStockOnHandRepository.deleteAll(followingStockOnHands);
+            stockCard.getId(), lineItem.getOccurredDate())
+        .stream()
+        .collect(Collectors.toMap(CalculatedStockOnHand::getOccurredDate, soh -> soh,
+            (left, right) -> left));
 
     profiler.start("GET_FOLLOWING_STOCK_CARD_LINE_ITEMS");
     List<StockCardLineItem> followingLineItems = getFollowingLineItems(stockCard, lineItem);
@@ -208,9 +209,10 @@ public class CalculatedStockOnHandService {
     profiler.start("SAVE_RECALCULATED_STOCK_ON_HANDS");
     for (StockCardLineItem item : followingLineItems) {
       Integer calculatedStockOnHand = calculateStockOnHand(item, lineItemsPreviousStockOnHand);
-      saveCalculatedStockOnHand(item, calculatedStockOnHand, stockCard);
+      updateOrCreateCalculatedStockOnHand(existingByDate, item, calculatedStockOnHand, stockCard);
       lineItemsPreviousStockOnHand = calculatedStockOnHand;
     }
+    calculatedStockOnHandRepository.saveAll(existingByDate.values());
     profiler.stop().log();
   }
 
@@ -282,19 +284,18 @@ public class CalculatedStockOnHandService {
     }
   }
 
-  private void saveCalculatedStockOnHand(StockCardLineItem lineItem, Integer stockOnHand,
-      StockCard stockCard) {
-    Optional<CalculatedStockOnHand> stockOnHandOfExistingOccurredDate =
-        calculatedStockOnHandRepository.findFirstByStockCardIdAndOccurredDate(
-            stockCard.getId(), lineItem.getOccurredDate());
-
-    stockOnHandOfExistingOccurredDate.ifPresent((soh -> {
-      CalculatedStockOnHand existingStockOnHand = stockOnHandOfExistingOccurredDate.get();
-      calculatedStockOnHandRepository.delete(existingStockOnHand);
-    }));
-
-    calculatedStockOnHandRepository.save(new CalculatedStockOnHand(stockOnHand, stockCard,
-        lineItem.getOccurredDate(), lineItem.getProcessedDate()));
+  // Update the day's entry in place or create it if absent; saved later in one batch.
+  private void updateOrCreateCalculatedStockOnHand(
+      Map<LocalDate, CalculatedStockOnHand> existingByDate, StockCardLineItem lineItem,
+      Integer stockOnHand, StockCard stockCard) {
+    CalculatedStockOnHand existing = existingByDate.get(lineItem.getOccurredDate());
+    if (existing != null) {
+      existing.setStockOnHand(stockOnHand);
+      existing.setProcessedDate(lineItem.getProcessedDate());
+    } else {
+      existingByDate.put(lineItem.getOccurredDate(), new CalculatedStockOnHand(stockOnHand,
+          stockCard, lineItem.getOccurredDate(), lineItem.getProcessedDate()));
+    }
   }
 
   /**

--- a/src/main/resources/db/migration/20260529120000000__dedup_and_unique_calculated_stocks_on_hand.sql
+++ b/src/main/resources/db/migration/20260529120000000__dedup_and_unique_calculated_stocks_on_hand.sql
@@ -1,0 +1,14 @@
+-- OLMIS-8206: enforce one calculated_stocks_on_hand row per (stockcardid, occurreddate) by
+-- de-duplicating existing rows, adding a unique index, and dropping the redundant single-column index.
+
+DELETE FROM calculated_stocks_on_hand a
+    USING calculated_stocks_on_hand b
+WHERE a.stockcardid = b.stockcardid
+  AND a.occurreddate = b.occurreddate
+  AND (a.processeddate < b.processeddate
+      OR (a.processeddate = b.processeddate AND a.id < b.id));
+
+CREATE UNIQUE INDEX IF NOT EXISTS calculated_stocks_on_hand_card_date_unique_idx
+    ON calculated_stocks_on_hand (stockcardid, occurreddate);
+
+DROP INDEX IF EXISTS calculated_stocks_on_hand_index;


### PR DESCRIPTION
Updates calculated stock-on-hand rows in place instead of deleting and reinserting, and enforces one row per day.