### PR TITLE
SELV3-842: Count line item entries on transaction history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Improvements:
 * [ODRC-24](https://openlmis.atlassian.net/browse/ODRC-24) Global header and translations implemented for reports
 * [SELV3-748](https://openlmis.atlassian.net/browse/SELV3-748) Improved 'no permission' warning message
 * [SELV3-839](https://openlmis.atlassian.net/browse/SELV3-839) New document number generation for issue and receive
+* [SELV3-842](https://openlmis.atlassian.net/browse/SELV3-842) Added Transaction History view with new endpoints `GET /api/stockEvents` and `GET /api/stockEvents/{id}/lineItems`, plus a document number column on the stock card bin card report
 
 5.3.0 / 2025-11-27
 ==================

--- a/src/integration-test/java/org/openlmis/stockmanagement/repository/StockEventsRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/repository/StockEventsRepositoryIntegrationTest.java
@@ -162,7 +162,7 @@ public class StockEventsRepositoryIntegrationTest
   }
 
   @Test
-  public void shouldAggregateDistinctProductsAndEarliestOccurredDate() {
+  public void shouldCountLineItemEntriesAndEarliestOccurredDate() {
     UUID facility = randomUUID();
     UUID program = randomUUID();
     UUID orderableA = randomUUID();
@@ -184,7 +184,7 @@ public class StockEventsRepositoryIntegrationTest
     StockEventLineItemAggregate row = rows.get(0);
 
     assertThat(row.getStockEventId(), is(event.getId()));
-    assertThat(row.getNumberOfProducts(), is(2));
+    assertThat(row.getEntriesCount(), is(3));
     assertThat(row.getOccurredDate(), is(LocalDate.of(2026, 2, 10)));
   }
 

--- a/src/integration-test/java/org/openlmis/stockmanagement/web/StockEventsHistoryControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/web/StockEventsHistoryControllerIntegrationTest.java
@@ -85,6 +85,7 @@ public class StockEventsHistoryControllerIntegrationTest extends BaseWebTest {
         .id(UUID.randomUUID())
         .documentNumber("2026-06-FAC001-0001")
         .type(EventOrigin.ISSUE)
+        .entriesCount(3)
         .build();
 
     when(stockEventsService.search(any(StockEventSearchParams.class), any(Pageable.class)))
@@ -101,7 +102,8 @@ public class StockEventsHistoryControllerIntegrationTest extends BaseWebTest {
 
     resultActions.andExpect(status().isOk())
         .andExpect(jsonPath("$.content", hasSize(1)))
-        .andExpect(jsonPath("$.content[0].documentNumber", is("2026-06-FAC001-0001")));
+        .andExpect(jsonPath("$.content[0].documentNumber", is("2026-06-FAC001-0001")))
+        .andExpect(jsonPath("$.content[0].entriesCount", is(3)));
   }
 
   @Test

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventHistoryDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventHistoryDto.java
@@ -34,13 +34,13 @@ public class StockEventHistoryDto {
   private String documentNumber;
   private EventOrigin type;
   private LocalDate occurredDate;
-  private Integer numberOfProducts;
+  private Integer entriesCount;
   private UUID userId;
   private String username;
 
   /**
    * Creates a history row DTO from a stock event's scalar fields. The line-item-derived fields
-   * ({@code numberOfProducts}, {@code occurredDate}) and {@code username} are filled in afterwards
+   * ({@code entriesCount}, {@code occurredDate}) and {@code username} are filled in afterwards
    * by the service.
    */
   public static StockEventHistoryDto newInstance(StockEvent event) {

--- a/src/main/java/org/openlmis/stockmanagement/repository/StockEventsRepository.java
+++ b/src/main/java/org/openlmis/stockmanagement/repository/StockEventsRepository.java
@@ -33,11 +33,11 @@ public interface StockEventsRepository extends
    * does not trigger an N+1 over each event's line items.
    *
    * @param eventIds the stock event ids of the current page.
-   * @return one aggregate (event id, distinct product count, earliest occurred date) per event
+   * @return one aggregate (event id, line item entry count, earliest occurred date) per event
    *         that has line items.
    */
   @Query("SELECT new org.openlmis.stockmanagement.repository.custom.StockEventLineItemAggregate("
-      + "lineItem.stockEvent.id, COUNT(DISTINCT lineItem.orderableId),"
+      + "lineItem.stockEvent.id, COUNT(lineItem),"
       + " MIN(lineItem.occurredDate))"
       + " FROM StockEventLineItem lineItem"
       + " WHERE lineItem.stockEvent.id IN :eventIds"

--- a/src/main/java/org/openlmis/stockmanagement/repository/custom/StockEventLineItemAggregate.java
+++ b/src/main/java/org/openlmis/stockmanagement/repository/custom/StockEventLineItemAggregate.java
@@ -26,17 +26,17 @@ import lombok.Getter;
 public class StockEventLineItemAggregate {
 
   private final UUID stockEventId;
-  private final int numberOfProducts;
+  private final int entriesCount;
   private final LocalDate occurredDate;
 
   /**
-   * Creates an aggregate row; {@code numberOfProducts} comes in as a {@link Long} (from
-   * {@code COUNT(DISTINCT ...)}) and is narrowed to an int.
+   * Creates an aggregate row; {@code entriesCount} comes in as a {@link Long} (from
+   * {@code COUNT(...)}) and is narrowed to an int.
    */
-  public StockEventLineItemAggregate(UUID stockEventId, Long numberOfProducts,
+  public StockEventLineItemAggregate(UUID stockEventId, Long entriesCount,
       LocalDate occurredDate) {
     this.stockEventId = stockEventId;
-    this.numberOfProducts = numberOfProducts == null ? 0 : numberOfProducts.intValue();
+    this.entriesCount = entriesCount == null ? 0 : entriesCount.intValue();
     this.occurredDate = occurredDate;
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventsService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventsService.java
@@ -98,9 +98,9 @@ public class StockEventsService {
       StockEventLineItemAggregate aggregate) {
     StockEventHistoryDto dto = StockEventHistoryDto.newInstance(event);
     if (aggregate == null) {
-      dto.setNumberOfProducts(0);
+      dto.setEntriesCount(0);
     } else {
-      dto.setNumberOfProducts(aggregate.getNumberOfProducts());
+      dto.setEntriesCount(aggregate.getEntriesCount());
       dto.setOccurredDate(aggregate.getOccurredDate());
     }
     return dto;

--- a/src/main/resources/schemas/stockEventHistoryDto.json
+++ b/src/main/resources/schemas/stockEventHistoryDto.json
@@ -21,9 +21,9 @@
       "type": ["string", "null"],
       "description": "Earliest occurred date across the event's line items (ISO date)."
     },
-    "numberOfProducts": {
+    "entriesCount": {
       "type": ["integer", "null"],
-      "description": "Count of distinct products in the event."
+      "description": "Count of stock event line item entries in the event."
     },
     "userId": {
       "type": ["string", "null"],

--- a/src/test/java/org/openlmis/stockmanagement/dto/StockEventHistoryDtoTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/dto/StockEventHistoryDtoTest.java
@@ -54,7 +54,7 @@ public class StockEventHistoryDtoTest {
 
     StockEventHistoryDto dto = StockEventHistoryDto.newInstance(event);
 
-    assertThat(dto.getNumberOfProducts(), is(nullValue()));
+    assertThat(dto.getEntriesCount(), is(nullValue()));
     assertThat(dto.getOccurredDate(), is(nullValue()));
   }
 

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventsServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventsServiceTest.java
@@ -110,7 +110,7 @@ public class StockEventsServiceTest {
   }
 
   @Test
-  public void searchShouldPopulateNumberOfProductsAndOccurredDateFromAggregate() {
+  public void searchShouldPopulateEntriesCountAndOccurredDateFromAggregate() {
     StockEvent event = new StockEventDataBuilder()
         .withEventOrigin(EventOrigin.ISSUE).build();
     StockEventSearchParams params = new StockEventSearchParams(randomUUID(), randomUUID(),
@@ -126,12 +126,12 @@ public class StockEventsServiceTest {
 
     StockEventHistoryDto dto = result.getContent().get(0);
 
-    assertThat(dto.getNumberOfProducts(), is(3));
+    assertThat(dto.getEntriesCount(), is(3));
     assertThat(dto.getOccurredDate(), is(LocalDate.of(2026, 2, 10)));
   }
 
   @Test
-  public void searchShouldDefaultNumberOfProductsToZeroWhenEventHasNoAggregate() {
+  public void searchShouldDefaultEntriesCountToZeroWhenEventHasNoAggregate() {
     StockEvent event = new StockEventDataBuilder()
         .withEventOrigin(EventOrigin.ISSUE).build();
     StockEventSearchParams params = new StockEventSearchParams(randomUUID(), randomUUID(),
@@ -144,7 +144,7 @@ public class StockEventsServiceTest {
 
     StockEventHistoryDto dto = result.getContent().get(0);
 
-    assertThat(dto.getNumberOfProducts(), is(0));
+    assertThat(dto.getEntriesCount(), is(0));
     assertThat(dto.getOccurredDate(), is(nullValue()));
   }
 


### PR DESCRIPTION
Transaction history counts stock event line item rows instead of distinct products.