### PR TITLE
Selv3 849

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Upcoming Version (WIP)
 ==================
-* [SELV3-841](https://openlmis.atlassian.net/browse/SELV3-841) Added `GET /api/stockEvents/{id}/print` 
-  endpoint for generating PDF report for stock event transactions
+* [SELV3-849](https://openlmis.atlassian.net/browse/SELV3-849) Unified StockCardLineItem ordering on retrieval
+* [SELV3-842](https://openlmis.atlassian.net/browse/SELV3-842) Added `GET /api/stockEvents/{id}` endpoint
+* [SELV3-841](https://openlmis.atlassian.net/browse/SELV3-841) Added `GET /api/stockEvents/{id}/print` endpoint for generating PDF report for stock event transactions
 
 5.3.1 / 2026-06-09
 ==================

--- a/src/integration-test/java/org/openlmis/stockmanagement/web/StockEventsHistoryControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/web/StockEventsHistoryControllerIntegrationTest.java
@@ -48,6 +48,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.web.servlet.ResultActions;
 
+@SuppressWarnings("PMD.TooManyMethods")
 public class StockEventsHistoryControllerIntegrationTest extends BaseWebTest {
 
   private static final String STOCK_EVENTS_URL = "/api/stockEvents";
@@ -183,6 +184,53 @@ public class StockEventsHistoryControllerIntegrationTest extends BaseWebTest {
 
     ResultActions resultActions = mvc.perform(
         get(STOCK_EVENTS_URL + "/" + eventId + "/lineItems")
+            .param(ACCESS_TOKEN, ACCESS_TOKEN_VALUE));
+
+    resultActions.andExpect(status().isNotFound());
+  }
+
+  @Test
+  public void shouldReturn403WhenUserCannotViewStockEventHeader() throws Exception {
+    UUID eventId = UUID.randomUUID();
+    doThrow(new PermissionMessageException(new Message("no permission")))
+        .when(stockEventsService).findStockEvent(eq(eventId));
+
+    ResultActions resultActions = mvc.perform(
+        get(STOCK_EVENTS_URL + "/" + eventId)
+            .param(ACCESS_TOKEN, ACCESS_TOKEN_VALUE));
+
+    resultActions.andExpect(status().isForbidden());
+  }
+
+  @Test
+  public void shouldGetStockEventHeader() throws Exception {
+    UUID eventId = UUID.randomUUID();
+    StockEventHistoryDto dto = StockEventHistoryDto.builder()
+        .id(eventId)
+        .documentNumber("DOC-1")
+        .type(EventOrigin.RECEIVE)
+        .build();
+
+    when(stockEventsService.findStockEvent(eq(eventId))).thenReturn(dto);
+
+    ResultActions resultActions = mvc.perform(
+        get(STOCK_EVENTS_URL + "/" + eventId)
+            .param(ACCESS_TOKEN, ACCESS_TOKEN_VALUE));
+
+    resultActions.andExpect(status().isOk())
+        .andExpect(jsonPath("$.id", is(eventId.toString())))
+        .andExpect(jsonPath("$.type", is(EventOrigin.RECEIVE.toString())))
+        .andExpect(jsonPath("$.documentNumber", is("DOC-1")));
+  }
+
+  @Test
+  public void shouldReturnNotFoundWhenStockEventHeaderDoesNotExist() throws Exception {
+    UUID eventId = UUID.randomUUID();
+    doThrow(new ResourceNotFoundException(new Message("stock event not found")))
+        .when(stockEventsService).findStockEvent(eq(eventId));
+
+    ResultActions resultActions = mvc.perform(
+        get(STOCK_EVENTS_URL + "/" + eventId)
             .param(ACCESS_TOKEN, ACCESS_TOKEN_VALUE));
 
     resultActions.andExpect(status().isNotFound());

--- a/src/main/java/org/openlmis/stockmanagement/domain/card/StockCard.java
+++ b/src/main/java/org/openlmis/stockmanagement/domain/card/StockCard.java
@@ -18,6 +18,7 @@ package org.openlmis.stockmanagement.domain.card;
 import static javax.persistence.CascadeType.ALL;
 import static org.apache.commons.beanutils.BeanUtils.cloneBean;
 import static org.hibernate.annotations.LazyCollectionOption.FALSE;
+import static org.openlmis.stockmanagement.domain.card.StockCardLineItemComparators.byId;
 import static org.openlmis.stockmanagement.domain.card.StockCardLineItemComparators.byOccurredDate;
 import static org.openlmis.stockmanagement.domain.card.StockCardLineItemComparators.byProcessedDate;
 import static org.openlmis.stockmanagement.domain.card.StockCardLineItemComparators.byReasonPriority;
@@ -186,6 +187,7 @@ public class StockCard extends BaseEntity implements IdentifiableByOrderableLot 
   public static Comparator<StockCardLineItem> getLineItemsComparator() {
     return byOccurredDate()
         .thenComparing(byProcessedDate())
-        .thenComparing(byReasonPriority());
+        .thenComparing(byReasonPriority())
+        .thenComparing(byId());
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/domain/card/StockCardLineItemComparators.java
+++ b/src/main/java/org/openlmis/stockmanagement/domain/card/StockCardLineItemComparators.java
@@ -21,6 +21,7 @@ public final class StockCardLineItemComparators {
   private static final Comparator<StockCardLineItem> BY_OCCURRED_DATE = new ByOccurredDate();
   private static final Comparator<StockCardLineItem> BY_PROCESSED_DATE = new ByProcessedDate();
   private static final Comparator<StockCardLineItem> BY_REASON_PRIORITY = new ByReasonPriority();
+  private static final Comparator<StockCardLineItem> BY_ID = new ById();
 
   private StockCardLineItemComparators() {
     throw new UnsupportedOperationException();
@@ -36,6 +37,10 @@ public final class StockCardLineItemComparators {
 
   public static Comparator<StockCardLineItem> byReasonPriority() {
     return BY_REASON_PRIORITY;
+  }
+
+  public static Comparator<StockCardLineItem> byId() {
+    return BY_ID;
   }
 
   /**
@@ -80,6 +85,29 @@ public final class StockCardLineItemComparators {
 
       // the minus at the beginning is use to reverse the Integer.compare method
       return -Integer.compare(leftPriority, rightPriority);
+    }
+
+  }
+
+  /**
+   * Comparator that orders {@link StockCardLineItem} by their id. Used as the final, deterministic
+   * tie-breaker when occurred date, processed date and reason priority are all equal, so that the
+   * displayed order are stable across requests.
+   */
+  private static final class ById implements Comparator<StockCardLineItem> {
+
+    @Override
+    public int compare(StockCardLineItem left, StockCardLineItem right) {
+      String leftId = null != left.getId() ? left.getId().toString() : null;
+      String rightId = null != right.getId() ? right.getId().toString() : null;
+
+      if (leftId == null) {
+        return rightId == null ? 0 : 1;
+      }
+      if (rightId == null) {
+        return -1;
+      }
+      return leftId.compareTo(rightId);
     }
 
   }

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventsService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventsService.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.openlmis.stockmanagement.domain.event.StockEvent;
 import org.openlmis.stockmanagement.dto.StockCardDto;
+import org.openlmis.stockmanagement.dto.StockCardLineItemDto;
 import org.openlmis.stockmanagement.dto.StockEventHistoryDto;
 import org.openlmis.stockmanagement.dto.StockEventLineDetailDto;
 import org.openlmis.stockmanagement.dto.referencedata.UserDto;
@@ -146,10 +147,15 @@ public class StockEventsService {
     List<StockEventLineDetailDto> details = new ArrayList<>();
     stockCardService.findStockCardsByIds(cardIds).stream()
         .sorted(Comparator.comparing(StockCardDto::getId))
-        .forEach(card -> card.getLineItems().stream()
-            .filter(lineItem -> stockEventId.equals(lineItem.getOriginEventId()))
-            .forEach(lineItem ->
-                details.add(StockEventLineDetailDto.newInstance(card, lineItem))));
+        .forEach(card -> {
+          List<StockCardLineItemDto> items = card.getLineItems().stream()
+              .filter(lineItem -> stockEventId.equals(lineItem.getOriginEventId()))
+              .collect(Collectors.toList());
+          // Present newest-first to match the stock card view
+          Collections.reverse(items);
+          items.forEach(lineItem ->
+              details.add(StockEventLineDetailDto.newInstance(card, lineItem)));
+        });
 
     return Pagination.getPage(details, pageable);
   }

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventsService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventsService.java
@@ -159,4 +159,27 @@ public class StockEventsService {
 
     return Pagination.getPage(details, pageable);
   }
+
+  /**
+   * Returns the history header of a single stock event (the transaction detail header). The DTO
+   * has the same shape as the rows returned by {@link #search}, so the detail header stays
+   * consistent with the list.
+   *
+   * @param stockEventId the stock event id.
+   * @return the history row for the event.
+   */
+  public StockEventHistoryDto findStockEvent(UUID stockEventId) {
+    StockEvent event = stockEventsRepository.findById(stockEventId)
+        .orElseThrow(() -> new ResourceNotFoundException(
+            new Message(MessageKeys.ERROR_STOCK_EVENT_NOT_FOUND, stockEventId)));
+
+    permissionService.canViewStockCard(event.getProgramId(), event.getFacilityId());
+
+    Map<UUID, StockEventLineItemAggregate> aggregates =
+        aggregateLineItems(Collections.singletonList(event));
+    StockEventHistoryDto dto = toHistoryDto(event, aggregates.get(event.getId()));
+    populateUsernames(Collections.singletonList(dto));
+
+    return dto;
+  }
 }

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventsService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventsService.java
@@ -141,12 +141,19 @@ public class StockEventsService {
 
     List<UUID> cardIds = stockCardLineItemRepository.findStockCardIdsByOriginEvent(stockEventId);
 
-    // Cards are resolved in one batch (stock on hand and names), then ordered by id so the
-    // flattened line items have a stable order before in-memory pagination (findAllById gives no
-    // ordering guarantee). Only the line items belonging to this event are kept.
+    // Cards are resolved in one batch (stock on hand and names), then ordered to match the
+    // stockEvent.jrxml report (ORDER BY o.code, l.lotcode NULLS FIRST, rs.rn DESC): by product
+    // code, then lot code (nulls first), with the card id only as a final deterministic
+    // tiebreaker. Only the line items belonging to this event are kept.
+    Comparator<StockCardDto> byProductThenLot = Comparator
+        .comparing((StockCardDto card) -> card.getOrderable().getProductCode(),
+            Comparator.nullsLast(Comparator.naturalOrder()))
+        .thenComparing(card -> card.getLot() == null ? null : card.getLot().getLotCode(),
+            Comparator.nullsFirst(Comparator.naturalOrder()))
+        .thenComparing(StockCardDto::getId);
     List<StockEventLineDetailDto> details = new ArrayList<>();
     stockCardService.findStockCardsByIds(cardIds).stream()
-        .sorted(Comparator.comparing(StockCardDto::getId))
+        .sorted(byProductThenLot)
         .forEach(card -> {
           List<StockCardLineItemDto> items = card.getLineItems().stream()
               .filter(lineItem -> stockEventId.equals(lineItem.getOriginEventId()))

--- a/src/main/java/org/openlmis/stockmanagement/web/StockEventsController.java
+++ b/src/main/java/org/openlmis/stockmanagement/web/StockEventsController.java
@@ -142,6 +142,18 @@ public class StockEventsController extends BaseController {
   }
 
   /**
+   * Get the history header (e.g. event type, document number) of a single stock event.
+   *
+   * @return the event's history row.
+   */
+  @Transactional(readOnly = true)
+  @GetMapping("stockEvents/{id}")
+  @ResponseBody
+  public StockEventHistoryDto getStockEvent(@PathVariable UUID id) {
+    return stockEventsService.findStockEvent(id);
+  }
+
+  /**
    * Get the line items (transaction detail) of a single stock event.
    *
    * @return a page of the event's stock card line item details.

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -50,6 +50,7 @@ schemas:
   - stockEventExternalDto: !include schemas/stockEventExternalDto.json
   - stockEventLineItemExternalDto: !include schemas/stockEventLineItemExternalDto.json
   - stockEventHistoryDtoPage: !include schemas/stockEventHistoryDto.json
+  - stockEventHistoryDto: !include schemas/stockEventHistoryDto.json
   - stockEventLineDetailDtoPage: !include schemas/stockEventLineDetailDto.json
 
   - stockCard: !include schemas/stockCard.json
@@ -318,6 +319,25 @@ traits:
             type: string
             required: true
             repeat: false
+        get:
+          is: [ secured ]
+          description: Get the history header (e.g. event type, document number) of a single stock event.
+          responses:
+            200:
+              description: The stock event's history header.
+              body:
+                application/json:
+                  schema: stockEventHistoryDto
+            403:
+              description: User does not have permission to view stock cards.
+              body:
+                application/json:
+                  schema: localizedMessage
+            404:
+              description: Stock event with the given id does not exist.
+              body:
+                application/json:
+                  schema: localizedMessage
         /lineItems:
           get:
             is: [ secured, paginated ]

--- a/src/main/resources/jasperTemplates/stockEvent.jrxml
+++ b/src/main/resources/jasperTemplates/stockEvent.jrxml
@@ -38,9 +38,9 @@ ordered_items AS (
                     WHEN 'BALANCE_ADJUSTMENT' THEN 0
                     ELSE -1
                 END DESC,
-                -- NOTE: ctid is physical row location and is only stable because line items are
-                -- never updated. This ordering mirrors order in stockCardSummaries view.
-                scli.ctid
+                -- final tie-break by id so the order is deterministic and matches the stock card
+                -- view, whose StockCard.getLineItemsComparator() ends with byId().
+                scli.id
         ) AS rn
     FROM stockmanagement.stock_card_line_items scli
     LEFT JOIN stockmanagement.stock_card_line_item_reasons sclir

--- a/src/test/java/org/openlmis/stockmanagement/domain/card/StockCardLineItemComparatorsTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/domain/card/StockCardLineItemComparatorsTest.java
@@ -156,7 +156,7 @@ public class StockCardLineItemComparatorsTest {
   }
 
   @Test
-  public void shouldReturnZeroIfIdsAreSame() throws Exception {
+  public void shouldReturnZeroIfIdsAreSame() {
     // when
     UUID id = UUID.randomUUID();
     StockCardLineItem left = new StockCardLineItemDataBuilder().withId(id).build();
@@ -167,7 +167,7 @@ public class StockCardLineItemComparatorsTest {
   }
 
   @Test
-  public void shouldReturnNegativeIfFirstIdIsLowerInCanonicalOrder() throws Exception {
+  public void shouldReturnNegativeIfFirstIdIsLowerInCanonicalOrder() {
     // when
     StockCardLineItem left = new StockCardLineItemDataBuilder()
         .withId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
@@ -181,7 +181,7 @@ public class StockCardLineItemComparatorsTest {
   }
 
   @Test
-  public void shouldReturnPositiveIfFirstIdIsHigherInCanonicalOrder() throws Exception {
+  public void shouldReturnPositiveIfFirstIdIsHigherInCanonicalOrder() {
     // when
     StockCardLineItem left = new StockCardLineItemDataBuilder()
         .withId(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"))
@@ -195,7 +195,7 @@ public class StockCardLineItemComparatorsTest {
   }
 
   @Test
-  public void shouldOrderByCanonicalStringNotSignedLongs() throws Exception {
+  public void shouldOrderByCanonicalStringNotSignedLongs() {
     // when
     StockCardLineItem low = new StockCardLineItemDataBuilder()
         .withId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
@@ -209,7 +209,7 @@ public class StockCardLineItemComparatorsTest {
   }
 
   @Test
-  public void shouldOrderNullIdLast() throws Exception {
+  public void shouldOrderNullIdLast() {
     // when
     StockCardLineItem withId = new StockCardLineItemDataBuilder()
         .withId(UUID.randomUUID())

--- a/src/test/java/org/openlmis/stockmanagement/domain/card/StockCardLineItemComparatorsTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/domain/card/StockCardLineItemComparatorsTest.java
@@ -19,10 +19,12 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
+import static org.openlmis.stockmanagement.domain.card.StockCardLineItemComparators.byId;
 import static org.openlmis.stockmanagement.domain.card.StockCardLineItemComparators.byOccurredDate;
 import static org.openlmis.stockmanagement.domain.card.StockCardLineItemComparators.byProcessedDate;
 import static org.openlmis.stockmanagement.domain.card.StockCardLineItemComparators.byReasonPriority;
 
+import java.util.UUID;
 import org.junit.Test;
 import org.openlmis.stockmanagement.testutils.StockCardLineItemDataBuilder;
 
@@ -151,5 +153,71 @@ public class StockCardLineItemComparatorsTest {
 
     // then
     assertThat(byReasonPriority().compare(left, right), lessThan(0));
+  }
+
+  @Test
+  public void shouldReturnZeroIfIdsAreSame() throws Exception {
+    // when
+    UUID id = UUID.randomUUID();
+    StockCardLineItem left = new StockCardLineItemDataBuilder().withId(id).build();
+    StockCardLineItem right = new StockCardLineItemDataBuilder().withId(id).build();
+
+    // then
+    assertThat(byId().compare(left, right), is(0));
+  }
+
+  @Test
+  public void shouldReturnNegativeIfFirstIdIsLowerInCanonicalOrder() throws Exception {
+    // when
+    StockCardLineItem left = new StockCardLineItemDataBuilder()
+        .withId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        .build();
+    StockCardLineItem right = new StockCardLineItemDataBuilder()
+        .withId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+        .build();
+
+    // then
+    assertThat(byId().compare(left, right), lessThan(0));
+  }
+
+  @Test
+  public void shouldReturnPositiveIfFirstIdIsHigherInCanonicalOrder() throws Exception {
+    // when
+    StockCardLineItem left = new StockCardLineItemDataBuilder()
+        .withId(UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"))
+        .build();
+    StockCardLineItem right = new StockCardLineItemDataBuilder()
+        .withId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        .build();
+
+    // then
+    assertThat(byId().compare(left, right), greaterThan(0));
+  }
+
+  @Test
+  public void shouldOrderByCanonicalStringNotSignedLongs() throws Exception {
+    // when
+    StockCardLineItem low = new StockCardLineItemDataBuilder()
+        .withId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
+        .build();
+    StockCardLineItem high = new StockCardLineItemDataBuilder()
+        .withId(UUID.fromString("f0000000-0000-0000-0000-000000000000"))
+        .build();
+
+    // then
+    assertThat(byId().compare(low, high), lessThan(0));
+  }
+
+  @Test
+  public void shouldOrderNullIdLast() throws Exception {
+    // when
+    StockCardLineItem withId = new StockCardLineItemDataBuilder()
+        .withId(UUID.randomUUID())
+        .build();
+    StockCardLineItem withoutId = new StockCardLineItemDataBuilder().withoutId().build();
+
+    // then
+    assertThat(byId().compare(withId, withoutId), lessThan(0));
+    assertThat(byId().compare(withoutId, withId), greaterThan(0));
   }
 }

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventsServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventsServiceTest.java
@@ -59,6 +59,10 @@ import org.springframework.data.domain.Pageable;
 @RunWith(MockitoJUnitRunner.class)
 public class StockEventsServiceTest {
 
+  private static final String DOC_1 = "DOC-1";
+  private static final String DOC_2 = "DOC-2";
+  private static final String DOC_3 = "DOC-3";
+
   @Mock
   private StockEventsRepository stockEventsRepository;
 
@@ -85,10 +89,10 @@ public class StockEventsServiceTest {
     UUID userB = randomUUID();
 
     StockEvent event1 = new StockEventDataBuilder()
-        .withEventOrigin(EventOrigin.ISSUE).withDocumentNumber("DOC-1").build();
+        .withEventOrigin(EventOrigin.ISSUE).withDocumentNumber(DOC_1).build();
     event1.setUserId(userA);
     StockEvent event2 = new StockEventDataBuilder()
-        .withEventOrigin(EventOrigin.RECEIVE).withDocumentNumber("DOC-2").build();
+        .withEventOrigin(EventOrigin.RECEIVE).withDocumentNumber(DOC_2).build();
     event2.setUserId(userB);
 
     StockEventSearchParams params = new StockEventSearchParams(randomUUID(), randomUUID(),
@@ -103,9 +107,9 @@ public class StockEventsServiceTest {
 
     assertThat(result.getTotalElements(), is(2L));
     assertThat(result.getContent(), hasSize(2));
-    assertThat(result.getContent().get(0).getDocumentNumber(), is("DOC-1"));
+    assertThat(result.getContent().get(0).getDocumentNumber(), is(DOC_1));
     assertThat(result.getContent().get(0).getUsername(), is("alice"));
-    assertThat(result.getContent().get(1).getDocumentNumber(), is("DOC-2"));
+    assertThat(result.getContent().get(1).getDocumentNumber(), is(DOC_2));
     assertThat(result.getContent().get(1).getUsername(), is("bob"));
   }
 
@@ -193,6 +197,46 @@ public class StockEventsServiceTest {
     assertThat(detail.getStockOnHand(), is(20));
     assertThat(detail.getDocumentNumber(), is("DOC-MATCH"));
     verify(permissionService).canViewStockCard(program, facility);
+  }
+
+  @Test
+  public void findStockEventLineItemsShouldReturnLinesNewestFirst() {
+    UUID facility = randomUUID();
+    UUID program = randomUUID();
+    StockEvent event = new StockEventDataBuilder()
+        .withFacility(facility).withProgram(program).withEventOrigin(EventOrigin.ISSUE).build();
+    UUID eventId = event.getId();
+    UUID cardId = randomUUID();
+
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
+    when(stockCardLineItemRepository.findStockCardIdsByOriginEvent(eventId))
+        .thenReturn(singletonList(cardId));
+
+    // Provided in the canonical comparator order (as card.getLineItems() yields them); the
+    // service must present them reversed (newest-first) to match the stock card view and
+    // stockEvent.jrxml.
+    StockCardLineItemDto first = StockCardLineItemDto.builder()
+        .lineItem(new StockCardLineItemDataBuilder().withDocumentNumber(DOC_1).build())
+        .originEventId(eventId).build();
+    StockCardLineItemDto second = StockCardLineItemDto.builder()
+        .lineItem(new StockCardLineItemDataBuilder().withDocumentNumber(DOC_2).build())
+        .originEventId(eventId).build();
+    StockCardLineItemDto third = StockCardLineItemDto.builder()
+        .lineItem(new StockCardLineItemDataBuilder().withDocumentNumber(DOC_3).build())
+        .originEventId(eventId).build();
+    StockCardDto cardDto = StockCardDto.builder()
+        .orderable(OrderableDto.builder().productCode("ABC").build())
+        .lineItems(asList(first, second, third)).build();
+    when(stockCardService.findStockCardsByIds(anyCollection()))
+        .thenReturn(singletonList(cardDto));
+
+    Page<StockEventLineDetailDto> result =
+        stockEventsService.findStockEventLineItems(eventId, pageable);
+
+    assertThat(result.getContent(), hasSize(3));
+    assertThat(result.getContent().get(0).getDocumentNumber(), is(DOC_3));
+    assertThat(result.getContent().get(1).getDocumentNumber(), is(DOC_2));
+    assertThat(result.getContent().get(2).getDocumentNumber(), is(DOC_1));
   }
 
   @Test(expected = ResourceNotFoundException.class)

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventsServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventsServiceTest.java
@@ -42,6 +42,7 @@ import org.openlmis.stockmanagement.dto.StockCardDto;
 import org.openlmis.stockmanagement.dto.StockCardLineItemDto;
 import org.openlmis.stockmanagement.dto.StockEventHistoryDto;
 import org.openlmis.stockmanagement.dto.StockEventLineDetailDto;
+import org.openlmis.stockmanagement.dto.referencedata.LotDto;
 import org.openlmis.stockmanagement.dto.referencedata.OrderableDto;
 import org.openlmis.stockmanagement.dto.referencedata.UserDto;
 import org.openlmis.stockmanagement.exception.ResourceNotFoundException;
@@ -58,6 +59,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 @RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("PMD.TooManyMethods")
 public class StockEventsServiceTest {
 
   private static final String DOC_1 = "DOC-1";
@@ -239,6 +241,44 @@ public class StockEventsServiceTest {
     assertThat(result.getContent().get(0).getDocumentNumber(), is(DOC_3));
     assertThat(result.getContent().get(1).getDocumentNumber(), is(DOC_2));
     assertThat(result.getContent().get(2).getDocumentNumber(), is(DOC_1));
+  }
+
+  @Test
+  public void findStockEventLineItemsShouldOrderCardsByProductCodeThenLot() {
+    StockEvent event = new StockEventDataBuilder()
+        .withFacility(randomUUID()).withProgram(randomUUID())
+        .withEventOrigin(EventOrigin.ISSUE).build();
+    UUID eventId = event.getId();
+
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
+    when(stockCardLineItemRepository.findStockCardIdsByOriginEvent(eventId))
+        .thenReturn(asList(randomUUID(), randomUUID(), randomUUID()));
+
+    StockCardDto productAnoLot = cardWithLine("AAA", null, eventId, DOC_1);
+    StockCardDto productALotL2 = cardWithLine("AAA", "L2", eventId, DOC_2);
+    StockCardDto productB = cardWithLine("BBB", null, eventId, DOC_3);
+    when(stockCardService.findStockCardsByIds(anyCollection()))
+        .thenReturn(asList(productB, productALotL2, productAnoLot));
+
+    Page<StockEventLineDetailDto> result =
+        stockEventsService.findStockEventLineItems(eventId, pageable);
+
+    assertThat(result.getContent(), hasSize(3));
+    assertThat(result.getContent().get(0).getDocumentNumber(), is(DOC_1));
+    assertThat(result.getContent().get(1).getDocumentNumber(), is(DOC_2));
+    assertThat(result.getContent().get(2).getDocumentNumber(), is(DOC_3));
+  }
+
+  private StockCardDto cardWithLine(String productCode, String lotCode, UUID eventId,
+      String documentNumber) {
+    StockCardLineItemDto line = StockCardLineItemDto.builder()
+        .lineItem(new StockCardLineItemDataBuilder().withDocumentNumber(documentNumber).build())
+        .originEventId(eventId).build();
+    return StockCardDto.builder()
+        .id(randomUUID())
+        .orderable(OrderableDto.builder().productCode(productCode).build())
+        .lot(lotCode == null ? null : LotDto.builder().lotCode(lotCode).build())
+        .lineItems(singletonList(line)).build();
   }
 
   @Test(expected = ResourceNotFoundException.class)

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventsServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventsServiceTest.java
@@ -62,6 +62,7 @@ public class StockEventsServiceTest {
   private static final String DOC_1 = "DOC-1";
   private static final String DOC_2 = "DOC-2";
   private static final String DOC_3 = "DOC-3";
+  private static final String ALICE = "alice";
 
   @Mock
   private StockEventsRepository stockEventsRepository;
@@ -101,14 +102,14 @@ public class StockEventsServiceTest {
     when(stockEventsRepository.search(params, pageable))
         .thenReturn(new PageImpl<>(asList(event1, event2), pageable, 2));
     when(userReferenceDataService.findUsersByIds(anySet()))
-        .thenReturn(asList(userDto(userA, "alice"), userDto(userB, "bob")));
+        .thenReturn(asList(userDto(userA, ALICE), userDto(userB, "bob")));
 
     Page<StockEventHistoryDto> result = stockEventsService.search(params, pageable);
 
     assertThat(result.getTotalElements(), is(2L));
     assertThat(result.getContent(), hasSize(2));
     assertThat(result.getContent().get(0).getDocumentNumber(), is(DOC_1));
-    assertThat(result.getContent().get(0).getUsername(), is("alice"));
+    assertThat(result.getContent().get(0).getUsername(), is(ALICE));
     assertThat(result.getContent().get(1).getDocumentNumber(), is(DOC_2));
     assertThat(result.getContent().get(1).getUsername(), is("bob"));
   }
@@ -245,5 +246,42 @@ public class StockEventsServiceTest {
     when(stockEventsRepository.findById(eventId)).thenReturn(Optional.empty());
 
     stockEventsService.findStockEventLineItems(eventId, pageable);
+  }
+
+  @Test
+  public void findStockEventShouldReturnHistoryHeaderForEvent() {
+    UUID facility = randomUUID();
+    UUID program = randomUUID();
+    UUID user = randomUUID();
+    StockEvent event = new StockEventDataBuilder()
+        .withFacility(facility).withProgram(program)
+        .withEventOrigin(EventOrigin.RECEIVE).withDocumentNumber(DOC_1).build();
+    event.setUserId(user);
+    UUID eventId = event.getId();
+
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
+    when(stockEventsRepository.aggregateLineItemsByEventIds(anySet()))
+        .thenReturn(singletonList(
+            new StockEventLineItemAggregate(eventId, 3L, LocalDate.of(2026, 2, 10))));
+    when(userReferenceDataService.findUsersByIds(anySet()))
+        .thenReturn(singletonList(userDto(user, ALICE)));
+
+    StockEventHistoryDto dto = stockEventsService.findStockEvent(eventId);
+
+    assertThat(dto.getId(), is(eventId));
+    assertThat(dto.getType(), is(EventOrigin.RECEIVE));
+    assertThat(dto.getDocumentNumber(), is(DOC_1));
+    assertThat(dto.getEntriesCount(), is(3));
+    assertThat(dto.getOccurredDate(), is(LocalDate.of(2026, 2, 10)));
+    assertThat(dto.getUsername(), is(ALICE));
+    verify(permissionService).canViewStockCard(program, facility);
+  }
+
+  @Test(expected = ResourceNotFoundException.class)
+  public void findStockEventShouldThrowWhenEventNotFound() {
+    UUID eventId = randomUUID();
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.empty());
+
+    stockEventsService.findStockEvent(eventId);
   }
 }

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventsServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventsServiceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.Test;
@@ -124,15 +125,15 @@ public class StockEventsServiceTest {
     when(stockEventsRepository.search(params, pageable))
         .thenReturn(new PageImpl<>(singletonList(event), pageable, 1));
     when(stockEventsRepository.aggregateLineItemsByEventIds(anySet()))
-        .thenReturn(singletonList(
-            new StockEventLineItemAggregate(event.getId(), 3L, LocalDate.of(2026, 2, 10))));
+        .thenReturn(singletonList(new StockEventLineItemAggregate(
+            event.getId(), 3L, LocalDate.of(2026, Month.FEBRUARY, 10))));
 
     Page<StockEventHistoryDto> result = stockEventsService.search(params, pageable);
 
     StockEventHistoryDto dto = result.getContent().get(0);
 
     assertThat(dto.getEntriesCount(), is(3));
-    assertThat(dto.getOccurredDate(), is(LocalDate.of(2026, 2, 10)));
+    assertThat(dto.getOccurredDate(), is(LocalDate.of(2026, Month.FEBRUARY, 10)));
   }
 
   @Test
@@ -262,7 +263,7 @@ public class StockEventsServiceTest {
     when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
     when(stockEventsRepository.aggregateLineItemsByEventIds(anySet()))
         .thenReturn(singletonList(
-            new StockEventLineItemAggregate(eventId, 3L, LocalDate.of(2026, 2, 10))));
+            new StockEventLineItemAggregate(eventId, 3L, LocalDate.of(2026, Month.FEBRUARY, 10))));
     when(userReferenceDataService.findUsersByIds(anySet()))
         .thenReturn(singletonList(userDto(user, ALICE)));
 
@@ -272,7 +273,7 @@ public class StockEventsServiceTest {
     assertThat(dto.getType(), is(EventOrigin.RECEIVE));
     assertThat(dto.getDocumentNumber(), is(DOC_1));
     assertThat(dto.getEntriesCount(), is(3));
-    assertThat(dto.getOccurredDate(), is(LocalDate.of(2026, 2, 10)));
+    assertThat(dto.getOccurredDate(), is(LocalDate.of(2026, Month.FEBRUARY, 10)));
     assertThat(dto.getUsername(), is(ALICE));
     verify(permissionService).canViewStockCard(program, facility);
   }

--- a/src/test/java/org/openlmis/stockmanagement/testutils/StockCardLineItemDataBuilder.java
+++ b/src/test/java/org/openlmis/stockmanagement/testutils/StockCardLineItemDataBuilder.java
@@ -112,6 +112,11 @@ public class StockCardLineItemDataBuilder {
     return this;
   }
 
+  public StockCardLineItemDataBuilder withId(UUID id) {
+    this.id = id;
+    return this;
+  }
+
   public StockCardLineItemDataBuilder withOriginEvent(StockEvent event) {
     originEvent = event;
     return this;


### PR DESCRIPTION
- StockCardLineItem comparator extended to compare by ID (to make the ordering deterministic across all the views that uses it)
- order of entries in transaction history view has been reversed (in order to match stock on hand details)
- added stockEvents/{id} GET endpoint to retrieve StockEvent dto for header
- fixed stockEvent report to align ordering with the views