### PR TITLE
SELV3-858 + SELV3-861: Cancel stock issue/receive movement - endpoint, handling & read-side cross-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Upcoming Version (WIP)
 ==================
+* [SELV3-858](https://openlmis.atlassian.net/browse/SELV3-858): Added `POST /api/stockEvents/{id}/cancel` endpoint to cancel selected issue/receive line items. Introduces the `STOCK_EVENTS_CANCEL` right, a `reverseseventlineitemid` column on stock event line items, and cancel-tagged adjustment reasons. Cancellation creates a reversing adjustment stock event and recalculates stock on hand; the original event is preserved.
 * [OLMIS-8198](https://openlmis.atlassian.net/browse/OLMIS-8198): Add packs support to stock card and stock card summary reports.
 * [SELV3-849](https://openlmis.atlassian.net/browse/SELV3-849) Unified StockCardLineItem ordering on retrieval
 * [SELV3-842](https://openlmis.atlassian.net/browse/SELV3-842) Added `GET /api/stockEvents/{id}` endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Upcoming Version (WIP)
 ==================
+* [SELV3-861](https://openlmis.atlassian.net/browse/SELV3-861): Resolve the "Reversing"/"Reversed by" cancellation cross-links on stock read DTOs and expose a stable `stockEventLineItemId` on the stock card and transaction-history line items, backed by a new `origineventlineitemid` column recording the stock event line item each stock card line item was created from. The column is populated for movements recorded from this version onward; movements recorded earlier have no stable line identifier and therefore cannot be cancelled through the reversal flow.
 * [SELV3-858](https://openlmis.atlassian.net/browse/SELV3-858): Added `POST /api/stockEvents/{id}/cancel` endpoint to cancel selected issue/receive line items. Introduces the `STOCK_EVENTS_CANCEL` right, a `reverseseventlineitemid` column on stock event line items, and cancel-tagged adjustment reasons. Cancellation creates a reversing adjustment stock event and recalculates stock on hand; the original event is preserved.
 * [OLMIS-8198](https://openlmis.atlassian.net/browse/OLMIS-8198): Add packs support to stock card and stock card summary reports.
 * [SELV3-849](https://openlmis.atlassian.net/browse/SELV3-849) Unified StockCardLineItem ordering on retrieval

--- a/src/integration-test/java/org/openlmis/stockmanagement/repository/PhysicalInventoriesRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/repository/PhysicalInventoriesRepositoryIntegrationTest.java
@@ -22,11 +22,14 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.Test;
+import org.openlmis.stockmanagement.domain.event.StockEvent;
 import org.openlmis.stockmanagement.domain.physicalinventory.PhysicalInventory;
 import org.openlmis.stockmanagement.domain.physicalinventory.PhysicalInventoryLineItem;
+import org.openlmis.stockmanagement.testutils.StockEventDataBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.CrudRepository;
 
@@ -34,9 +37,14 @@ public class PhysicalInventoriesRepositoryIntegrationTest
     extends BaseCrudRepositoryIntegrationTest<PhysicalInventory> {
 
   private static final LocalDate MOVEMENT_DATE = LocalDate.of(2026, 1, 1);
+  private static final ZonedDateTime MOVEMENT_PROCESSED =
+      ZonedDateTime.parse("2026-01-01T10:00:00Z");
 
   @Autowired
   private PhysicalInventoriesRepository repository;
+
+  @Autowired
+  private StockEventsRepository stockEventsRepository;
 
   @Override
   CrudRepository<PhysicalInventory, UUID> getRepository() {
@@ -63,10 +71,30 @@ public class PhysicalInventoriesRepositoryIntegrationTest
     save(program, facility, orderable, null, MOVEMENT_DATE.plusDays(1), false); // no lot
 
     List<PhysicalInventory> result = repository.findSubmittedAfterForOrderableAndLot(
-        program, facility, orderable, lot, MOVEMENT_DATE);
+        program, facility, orderable, lot, MOVEMENT_DATE, MOVEMENT_PROCESSED);
 
     assertThat(result, hasSize(1));
     assertThat(result.get(0).getId(), is(expected.getId()));
+  }
+
+  @Test
+  public void shouldReturnSameDayInventoryProcessedAfterTheMovementButNotBefore() {
+    UUID program = randomUUID();
+    UUID facility = randomUUID();
+    UUID orderable = randomUUID();
+    UUID lot = randomUUID();
+    // Same occurred date as the movement: the one processed AFTER it already reflects the movement
+    // and must block; the one processed BEFORE must not.
+    final PhysicalInventory processedAfter = saveWithEvent(program, facility, orderable, lot,
+        MOVEMENT_DATE, MOVEMENT_PROCESSED.plusHours(1));
+    saveWithEvent(program, facility, orderable, lot, MOVEMENT_DATE,
+        MOVEMENT_PROCESSED.minusHours(1));
+
+    List<PhysicalInventory> result = repository.findSubmittedAfterForOrderableAndLot(
+        program, facility, orderable, lot, MOVEMENT_DATE, MOVEMENT_PROCESSED);
+
+    assertThat(result, hasSize(1));
+    assertThat(result.get(0).getId(), is(processedAfter.getId()));
   }
 
   @Test
@@ -81,7 +109,7 @@ public class PhysicalInventoriesRepositoryIntegrationTest
     save(program, facility, orderable, randomUUID(), MOVEMENT_DATE.plusDays(1), false); // lot
 
     List<PhysicalInventory> result = repository.findSubmittedAfterForOrderableWithoutLot(
-        program, facility, orderable, MOVEMENT_DATE);
+        program, facility, orderable, MOVEMENT_DATE, MOVEMENT_PROCESSED);
 
     assertThat(result, hasSize(1));
     assertThat(result.get(0).getId(), is(expected.getId()));
@@ -90,6 +118,22 @@ public class PhysicalInventoriesRepositoryIntegrationTest
   private PhysicalInventory save(UUID program, UUID facility, UUID orderable, UUID lot,
       LocalDate occurredDate, boolean draft) {
     return repository.save(buildInventory(program, facility, orderable, lot, occurredDate, draft));
+  }
+
+  // Saves a submitted inventory linked to a stock event with the given processed date, so the
+  // occurred-date tiebreaker (StockCard ordering) can be exercised.
+  private PhysicalInventory saveWithEvent(UUID program, UUID facility, UUID orderable, UUID lot,
+      LocalDate occurredDate, ZonedDateTime processedDate) {
+    StockEvent event = stockEventsRepository.save(new StockEventDataBuilder()
+        .withoutId()
+        .withFacility(facility)
+        .withProgram(program)
+        .withProcessedDate(processedDate)
+        .build());
+    PhysicalInventory inventory = buildInventory(program, facility, orderable, lot, occurredDate,
+        false);
+    inventory.setStockEvent(event);
+    return repository.save(inventory);
   }
 
   private PhysicalInventory buildInventory(UUID program, UUID facility, UUID orderable, UUID lot,

--- a/src/integration-test/java/org/openlmis/stockmanagement/repository/PhysicalInventoriesRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/repository/PhysicalInventoriesRepositoryIntegrationTest.java
@@ -1,0 +1,111 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.repository;
+
+import static java.util.Collections.singletonList;
+import static java.util.UUID.randomUUID;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+import org.openlmis.stockmanagement.domain.physicalinventory.PhysicalInventory;
+import org.openlmis.stockmanagement.domain.physicalinventory.PhysicalInventoryLineItem;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.CrudRepository;
+
+public class PhysicalInventoriesRepositoryIntegrationTest
+    extends BaseCrudRepositoryIntegrationTest<PhysicalInventory> {
+
+  private static final LocalDate MOVEMENT_DATE = LocalDate.of(2026, 1, 1);
+
+  @Autowired
+  private PhysicalInventoriesRepository repository;
+
+  @Override
+  CrudRepository<PhysicalInventory, UUID> getRepository() {
+    return repository;
+  }
+
+  @Override
+  PhysicalInventory generateInstance() {
+    return buildInventory(randomUUID(), randomUUID(), randomUUID(), randomUUID(),
+        MOVEMENT_DATE, false);
+  }
+
+  @Test
+  public void shouldReturnSubmittedInventoryRecordedAfterMovementForOrderableAndLot() {
+    UUID program = randomUUID();
+    UUID facility = randomUUID();
+    UUID orderable = randomUUID();
+    UUID lot = randomUUID();
+    final PhysicalInventory expected =
+        save(program, facility, orderable, lot, MOVEMENT_DATE.plusDays(1), false);
+    save(program, facility, orderable, lot, MOVEMENT_DATE.plusDays(1), true); // draft
+    save(program, facility, orderable, lot, MOVEMENT_DATE.minusDays(1), false); // earlier
+    save(program, facility, randomUUID(), lot, MOVEMENT_DATE.plusDays(1), false); // other product
+    save(program, facility, orderable, null, MOVEMENT_DATE.plusDays(1), false); // no lot
+
+    List<PhysicalInventory> result = repository.findSubmittedAfterForOrderableAndLot(
+        program, facility, orderable, lot, MOVEMENT_DATE);
+
+    assertThat(result, hasSize(1));
+    assertThat(result.get(0).getId(), is(expected.getId()));
+  }
+
+  @Test
+  public void shouldReturnSubmittedInventoryRecordedAfterMovementForOrderableWithoutLot() {
+    UUID program = randomUUID();
+    UUID facility = randomUUID();
+    UUID orderable = randomUUID();
+    final PhysicalInventory expected =
+        save(program, facility, orderable, null, MOVEMENT_DATE.plusDays(1), false);
+    save(program, facility, orderable, null, MOVEMENT_DATE.plusDays(1), true); // draft
+    save(program, facility, orderable, null, MOVEMENT_DATE.minusDays(1), false); // earlier
+    save(program, facility, orderable, randomUUID(), MOVEMENT_DATE.plusDays(1), false); // lot
+
+    List<PhysicalInventory> result = repository.findSubmittedAfterForOrderableWithoutLot(
+        program, facility, orderable, MOVEMENT_DATE);
+
+    assertThat(result, hasSize(1));
+    assertThat(result.get(0).getId(), is(expected.getId()));
+  }
+
+  private PhysicalInventory save(UUID program, UUID facility, UUID orderable, UUID lot,
+      LocalDate occurredDate, boolean draft) {
+    return repository.save(buildInventory(program, facility, orderable, lot, occurredDate, draft));
+  }
+
+  private PhysicalInventory buildInventory(UUID program, UUID facility, UUID orderable, UUID lot,
+      LocalDate occurredDate, boolean draft) {
+    PhysicalInventory inventory = new PhysicalInventory();
+    inventory.setProgramId(program);
+    inventory.setFacilityId(facility);
+    inventory.setIsDraft(draft);
+    inventory.setOccurredDate(occurredDate);
+
+    PhysicalInventoryLineItem lineItem = new PhysicalInventoryLineItem();
+    lineItem.setOrderableId(orderable);
+    lineItem.setLotId(lot);
+    lineItem.setPhysicalInventory(inventory);
+    inventory.setLineItems(singletonList(lineItem));
+
+    return inventory;
+  }
+}

--- a/src/integration-test/java/org/openlmis/stockmanagement/service/StockEventProcessorIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/service/StockEventProcessorIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.openlmis.stockmanagement.service;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
@@ -33,6 +34,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.openlmis.stockmanagement.BaseIntegrationTest;
+import org.openlmis.stockmanagement.domain.card.StockCardLineItem;
 import org.openlmis.stockmanagement.domain.reason.ReasonCategory;
 import org.openlmis.stockmanagement.domain.reason.ReasonType;
 import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
@@ -191,6 +193,35 @@ public class StockEventProcessorIntegrationTest extends BaseIntegrationTest {
     //then
     assertSize(cardSize + 1, eventSize + 1, lineItemSize + 1);
     verify(stockEventNotificationProcessor).callAllNotifications(stockEventDto);
+  }
+
+  @Test
+  public void shouldRecordOriginEventLineItemIdOnGeneratedStockCardLineItem() {
+    StockEventDto stockEventDto = createStockEventDto();
+    stockEventDto.getLineItems().get(0).setReasonId(reason.getId());
+    stockEventDto.getLineItems().get(0).setSourceId(node.getId());
+    stockEventDto.getLineItems().get(0).setDestinationId(node.getId());
+    stockEventDto.setUserId(userId);
+    stockEventDto.setActive(true);
+    setContext(stockEventDto);
+
+    UUID savedEventId = stockEventProcessor.process(stockEventDto);
+
+    // the generated stock card line item records the persisted stock event line item it came from
+    UUID eventLineItemId = stockEventsRepository.findById(savedEventId)
+        .orElseThrow(AssertionError::new)
+        .getLineItems().get(0).getId();
+
+    StockCardLineItem generated = null;
+    for (StockCardLineItem item : lineItemRepository.findAll()) {
+      if (item.getOriginEvent() != null && savedEventId.equals(item.getOriginEvent().getId())) {
+        generated = item;
+        break;
+      }
+    }
+
+    assertThat(generated, is(notNullValue()));
+    assertThat(generated.getOriginEventLineItemId(), is(eventLineItemId));
   }
 
   @Test

--- a/src/integration-test/java/org/openlmis/stockmanagement/web/StockEventCancelIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/web/StockEventCancelIntegrationTest.java
@@ -1,0 +1,100 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_VALIDATION;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_NO_FOLLOWING_PERMISSION;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_STOCK_EVENT_NOT_FOUND;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.UUID;
+import org.junit.Test;
+import org.openlmis.stockmanagement.dto.StockEventCancelDto;
+import org.openlmis.stockmanagement.dto.StockEventCancellationLineErrorDto;
+import org.openlmis.stockmanagement.exception.PermissionMessageException;
+import org.openlmis.stockmanagement.exception.ResourceNotFoundException;
+import org.openlmis.stockmanagement.exception.StockEventCancellationException;
+import org.openlmis.stockmanagement.service.StockEventCancelService;
+import org.openlmis.stockmanagement.util.Message;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+public class StockEventCancelIntegrationTest extends BaseWebTest {
+
+  private static final String CANCEL_API = "/api/stockEvents/{id}/cancel";
+
+  @MockBean
+  private StockEventCancelService stockEventCancelService;
+
+  @Test
+  public void shouldReturn201WhenLineItemsCancelled() throws Exception {
+    UUID cancellationId = UUID.randomUUID();
+    when(stockEventCancelService.cancel(any(UUID.class), any(StockEventCancelDto.class)))
+        .thenReturn(cancellationId);
+
+    mvc.perform(post(CANCEL_API, UUID.randomUUID())
+        .param(ACCESS_TOKEN, ACCESS_TOKEN_VALUE)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectToJsonString(new StockEventCancelDto())))
+        .andExpect(status().isCreated())
+        .andExpect(content().string("\"" + cancellationId.toString() + "\""));
+  }
+
+  @Test
+  public void shouldReturn403WhenUserHasNoCancelPermission() throws Exception {
+    when(stockEventCancelService.cancel(any(UUID.class), any(StockEventCancelDto.class)))
+        .thenThrow(new PermissionMessageException(new Message(ERROR_NO_FOLLOWING_PERMISSION)));
+
+    mvc.perform(post(CANCEL_API, UUID.randomUUID())
+        .param(ACCESS_TOKEN, ACCESS_TOKEN_VALUE)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectToJsonString(new StockEventCancelDto())))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  public void shouldReturn404WhenEventDoesNotExist() throws Exception {
+    when(stockEventCancelService.cancel(any(UUID.class), any(StockEventCancelDto.class)))
+        .thenThrow(new ResourceNotFoundException(new Message(ERROR_STOCK_EVENT_NOT_FOUND)));
+
+    mvc.perform(post(CANCEL_API, UUID.randomUUID())
+        .param(ACCESS_TOKEN, ACCESS_TOKEN_VALUE)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectToJsonString(new StockEventCancelDto())))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  public void shouldReturn400WithLineErrorsWhenValidationFails() throws Exception {
+    StockEventCancellationLineErrorDto lineError = new StockEventCancellationLineErrorDto(
+        UUID.randomUUID(), ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE, null, null);
+    when(stockEventCancelService.cancel(any(UUID.class), any(StockEventCancelDto.class)))
+        .thenThrow(new StockEventCancellationException(
+            ERROR_EVENT_CANCELLATION_VALIDATION, Collections.singletonList(lineError)));
+
+    mvc.perform(post(CANCEL_API, UUID.randomUUID())
+        .param(ACCESS_TOKEN, ACCESS_TOKEN_VALUE)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectToJsonString(new StockEventCancelDto())))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/src/main/java/org/openlmis/stockmanagement/domain/card/StockCardLineItem.java
+++ b/src/main/java/org/openlmis/stockmanagement/domain/card/StockCardLineItem.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
     "stockCard", "originEvent",
     "source", "destination",
     "processedDate",
-    "userId"})
+    "userId", "originEventLineItemId"})
 @Table(name = "stock_card_line_items", schema = "stockmanagement")
 public class StockCardLineItem extends BaseEntity {
 
@@ -111,6 +111,11 @@ public class StockCardLineItem extends BaseEntity {
 
   @Column
   private UUID userId;
+
+  // The stock event line item this row was created from: lets reads expose a stable
+  // stockEventLineItemId to identify the exact line for cancellation and its cross-links.
+  @Column
+  private UUID originEventLineItemId;
 
   @Transient
   private Integer stockOnHand;
@@ -178,6 +183,7 @@ public class StockCardLineItem extends BaseEntity {
         .userId(eventDto.getContext().getCurrentUserId())
 
         .extraData(eventLineItem.getExtraData())
+        .originEventLineItemId(eventLineItem.getId())
         .build();
 
     stockCard.getLineItems().add(cardLineItem);

--- a/src/main/java/org/openlmis/stockmanagement/domain/event/StockEventLineItem.java
+++ b/src/main/java/org/openlmis/stockmanagement/domain/event/StockEventLineItem.java
@@ -105,4 +105,18 @@ public class StockEventLineItem extends BaseEntity
     return null;
   }
 
+  // An issue moves stock out to a destination; a receive brings it in from a source. Adjustments
+  // (including cancellations) have neither a source nor a destination.
+  public boolean isIssue() {
+    return destinationId != null;
+  }
+
+  public boolean isReceive() {
+    return sourceId != null;
+  }
+
+  public boolean isMovement() {
+    return isIssue() || isReceive();
+  }
+
 }

--- a/src/main/java/org/openlmis/stockmanagement/domain/event/StockEventLineItem.java
+++ b/src/main/java/org/openlmis/stockmanagement/domain/event/StockEventLineItem.java
@@ -73,6 +73,10 @@ public class StockEventLineItem extends BaseEntity
   private UUID destinationId;
   private String destinationFreeText;
 
+  // For a cancellation (ADJUSTMENT) line item, points to the original Issue/Receive
+  // StockEventLineItem it reverses. Null for regular movements.
+  private UUID reversesEventLineItemId;
+
   @ManyToOne()
   @JoinColumn(nullable = false)
   private StockEvent stockEvent;

--- a/src/main/java/org/openlmis/stockmanagement/dto/BlockingTransactionDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/BlockingTransactionDto.java
@@ -1,0 +1,36 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Describes a transaction that blocks a line item from being cancelled (e.g. a physical inventory
+ * recorded after the movement).
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BlockingTransactionDto {
+  private String type;
+  private LocalDate occurredDate;
+  private String documentNumber;
+}

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockCardLineItemDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockCardLineItemDto.java
@@ -37,6 +37,18 @@ public class StockCardLineItemDto {
   private UUID originEventId;
   private EventOrigin eventOrigin;
 
+  // Set on read for a cancellation line: the original event it reverses (the "Reversing" column).
+  private UUID reversedEventId;
+  private String reversedEventDocumentNumber;
+
+  // Set on read for an original line: the cancellation event that reversed it ("Reversed by").
+  private UUID cancellationEventId;
+  private String cancellationEventDocumentNumber;
+
+  // The stock event line item this row was created from: a stable, unique id the
+  // reverse view uses to cancel the exact line, and the resolver uses as the cross-link key.
+  private UUID stockEventLineItemId;
+
   /**
    * Create stock card line item dto from stock card line item.
    *
@@ -49,6 +61,7 @@ public class StockCardLineItemDto {
         .lineItem(stockCardLineItem)
         .originEventId(originEvent == null ? null : originEvent.getId())
         .eventOrigin(originEvent == null ? null : originEvent.getEventOrigin())
+        .stockEventLineItemId(stockCardLineItem.getOriginEventLineItemId())
         .build();
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventCancelDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventCancelDto.java
@@ -1,0 +1,34 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Request body for cancelling selected line items of an issue/receive stock event.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StockEventCancelDto {
+  private String signature;
+  private List<StockEventCancelLineItemDto> lineItems;
+}

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventCancelLineItemDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventCancelLineItemDto.java
@@ -1,0 +1,35 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * A single line item selected for cancellation together with the chosen cancellation reason.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StockEventCancelLineItemDto {
+  private UUID stockEventLineItemId;
+  private UUID reasonId;
+  private String reasonFreeText;
+}

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventCancellationErrorDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventCancellationErrorDto.java
@@ -1,0 +1,36 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Error body returned when one or more line items cannot be cancelled. Carries a general message
+ * plus the per-line errors so the client can flag which lines are blocking the action and why.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StockEventCancellationErrorDto {
+  private String messageKey;
+  private String message;
+  private List<StockEventCancellationLineErrorDto> lineErrors;
+}

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventCancellationLineErrorDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventCancellationLineErrorDto.java
@@ -1,0 +1,39 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.dto;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Describes why a single line item could not be cancelled. The {@code message} is filled in by the
+ * error handler when the exception is serialized; the validation layer only sets the key and the
+ * blocking transactions.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StockEventCancellationLineErrorDto {
+  private UUID stockEventLineItemId;
+  private String messageKey;
+  private String message;
+  private List<BlockingTransactionDto> blockingTransactions;
+}

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineDetailDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineDetailDto.java
@@ -16,6 +16,7 @@
 package org.openlmis.stockmanagement.dto;
 
 import java.time.LocalDate;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -42,6 +43,18 @@ public class StockEventLineDetailDto {
   private Integer stockOnHand;
   private String documentNumber;
 
+  // For a cancellation row: the original event it reverses ("Reversing" column). Null otherwise.
+  private UUID reversedEventId;
+  private String reversedEventDocumentNumber;
+
+  // For an original row: the cancellation event that reversed it ("Reversed by"). Null otherwise.
+  private UUID cancellationEventId;
+  private String cancellationEventDocumentNumber;
+
+  // The stock event line item this row corresponds to. The reverse view sends it to
+  // select the exact line to cancel, and per-line cancellation errors (AC#9) join on it.
+  private UUID stockEventLineItemId;
+
   /**
    * Flattens one resolved stock card line item (with its parent card's product/lot) into a single
    * transaction-history detail row.
@@ -63,6 +76,11 @@ public class StockEventLineDetailDto {
         .reason(item.getReason())
         .stockOnHand(item.getStockOnHand())
         .documentNumber(item.getDocumentNumber())
+        .reversedEventId(lineItem.getReversedEventId())
+        .reversedEventDocumentNumber(lineItem.getReversedEventDocumentNumber())
+        .cancellationEventId(lineItem.getCancellationEventId())
+        .cancellationEventDocumentNumber(lineItem.getCancellationEventDocumentNumber())
+        .stockEventLineItemId(lineItem.getStockEventLineItemId())
         .build();
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineItemDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineItemDto.java
@@ -41,6 +41,10 @@ import org.openlmis.stockmanagement.domain.physicalinventory.PhysicalInventoryLi
 @NoArgsConstructor
 @Builder
 public class StockEventLineItemDto implements IdentifiableByOrderableLot, VvmApplicable {
+  // Set server-side after the event is persisted (so generated stock card line items can record
+  // their origin); ignored if provided by clients on the create path.
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private UUID id;
   private UUID orderableId;
   private UUID lotId;
   private Integer quantity;

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineItemDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineItemDto.java
@@ -19,6 +19,7 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
 import static java.util.Collections.emptyList;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -52,13 +53,17 @@ public class StockEventLineItemDto implements IdentifiableByOrderableLot, VvmApp
   private String sourceFreeText;
   private UUID destinationId;
   private String destinationFreeText;
+  // Set server-side by the cancellation flow; ignored if provided by clients on the create path.
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private UUID reversesEventLineItemId;
   private List<StockEventAdjustmentDto> stockAdjustments;
 
   StockEventLineItem toEventLineItem() {
     // event is set in StockEventDto.toEvent()
     return new StockEventLineItem(
         orderableId, lotId, quantity, extraData, occurredDate, reasonId, reasonFreeText, sourceId,
-        sourceFreeText, destinationId, destinationFreeText, null, stockAdjustments()
+        sourceFreeText, destinationId, destinationFreeText, reversesEventLineItemId, null,
+        stockAdjustments()
     );
   }
 

--- a/src/main/java/org/openlmis/stockmanagement/errorhandling/GlobalErrorHandling.java
+++ b/src/main/java/org/openlmis/stockmanagement/errorhandling/GlobalErrorHandling.java
@@ -15,16 +15,20 @@
 
 package org.openlmis.stockmanagement.errorhandling;
 
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_CONCURRENT_MODIFICATION;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_LINE_ITEM_REASON_TAGS_INVALID;
 
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.persistence.PersistenceException;
+import org.openlmis.stockmanagement.dto.StockEventCancellationErrorDto;
+import org.openlmis.stockmanagement.dto.StockEventCancellationLineErrorDto;
 import org.openlmis.stockmanagement.exception.AuthenticationException;
 import org.openlmis.stockmanagement.exception.JasperReportViewException;
 import org.openlmis.stockmanagement.exception.PermissionMessageException;
 import org.openlmis.stockmanagement.exception.ResourceNotFoundException;
+import org.openlmis.stockmanagement.exception.StockEventCancellationException;
 import org.openlmis.stockmanagement.exception.ValidationMessageException;
 import org.openlmis.stockmanagement.service.referencedata.DataRetrievalException;
 import org.openlmis.stockmanagement.util.ErrorResponse;
@@ -42,6 +46,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ControllerAdvice
 public class GlobalErrorHandling extends AbstractErrorHandling {
   private static final Map<String, String> SQL_STATES = new HashMap<>();
+  private static final String UNIQUE_VIOLATION = "23505";
+  private static final String REVERSES_UNIQUE_INDEX =
+      "stock_event_line_items_reverses_unique_idx";
 
   static {
     // https://www.postgresql.org/docs/9.6/static/errcodes-appendix.html
@@ -111,6 +118,24 @@ public class GlobalErrorHandling extends AbstractErrorHandling {
   }
 
   /**
+   * Handles cancellation validation failures and returns status 400 with the per-line errors.
+   *
+   * @param ex the StockEventCancellationException to handle
+   * @return the error response listing which line items are blocking the cancellation and why
+   */
+  @ExceptionHandler(StockEventCancellationException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ResponseBody
+  public StockEventCancellationErrorDto handleStockEventCancellationException(
+      StockEventCancellationException ex) {
+    String message = getLocalizedMessage(ex.asMessage()).getMessage();
+    for (StockEventCancellationLineErrorDto lineError : ex.getLineErrors()) {
+      lineError.setMessage(getLocalizedMessage(lineError.getMessageKey()).getMessage());
+    }
+    return new StockEventCancellationErrorDto(ex.getMessageKey(), message, ex.getLineErrors());
+  }
+
+  /**
    * Handles Jpa System Exception.
    * @param ex the Jpa System Exception
    * @return the user-oriented error message.
@@ -131,9 +156,19 @@ public class GlobalErrorHandling extends AbstractErrorHandling {
         if (null != message) {
           return getLocalizedMessage(message);
         }
+
+        if (isReversesUniqueViolation(sql)) {
+          return getLocalizedMessage(ERROR_EVENT_CANCELLATION_CONCURRENT_MODIFICATION);
+        }
       }
     }
 
     return getLocalizedMessage(ex.getMessage());
+  }
+
+  private boolean isReversesUniqueViolation(SQLException sql) {
+    return UNIQUE_VIOLATION.equals(sql.getSQLState())
+        && null != sql.getMessage()
+        && sql.getMessage().contains(REVERSES_UNIQUE_INDEX);
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/errorhandling/GlobalErrorHandling.java
+++ b/src/main/java/org/openlmis/stockmanagement/errorhandling/GlobalErrorHandling.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.persistence.PersistenceException;
+import org.apache.commons.lang3.StringUtils;
 import org.openlmis.stockmanagement.dto.StockEventCancellationErrorDto;
 import org.openlmis.stockmanagement.dto.StockEventCancellationLineErrorDto;
 import org.openlmis.stockmanagement.exception.AuthenticationException;
@@ -168,7 +169,6 @@ public class GlobalErrorHandling extends AbstractErrorHandling {
 
   private boolean isReversesUniqueViolation(SQLException sql) {
     return UNIQUE_VIOLATION.equals(sql.getSQLState())
-        && null != sql.getMessage()
-        && sql.getMessage().contains(REVERSES_UNIQUE_INDEX);
+        && StringUtils.contains(sql.getMessage(), REVERSES_UNIQUE_INDEX);
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/exception/StockEventCancellationException.java
+++ b/src/main/java/org/openlmis/stockmanagement/exception/StockEventCancellationException.java
@@ -1,0 +1,50 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.exception;
+
+import java.util.List;
+import org.openlmis.stockmanagement.dto.StockEventCancellationLineErrorDto;
+
+/**
+ * Thrown when one or more line items selected for cancellation fail validation. Carries the
+ * per-line errors so the error handler can return which lines are blocking the action and why.
+ */
+public class StockEventCancellationException extends BaseMessageException {
+
+  private final String messageKey;
+  private final transient List<StockEventCancellationLineErrorDto> lineErrors;
+
+  /**
+   * Creates a new exception.
+   *
+   * @param messageKey the general message key describing the failure.
+   * @param lineErrors the per-line validation errors.
+   */
+  public StockEventCancellationException(String messageKey,
+      List<StockEventCancellationLineErrorDto> lineErrors) {
+    super(messageKey);
+    this.messageKey = messageKey;
+    this.lineErrors = lineErrors;
+  }
+
+  public String getMessageKey() {
+    return messageKey;
+  }
+
+  public List<StockEventCancellationLineErrorDto> getLineErrors() {
+    return lineErrors;
+  }
+}

--- a/src/main/java/org/openlmis/stockmanagement/i18n/MessageKeys.java
+++ b/src/main/java/org/openlmis/stockmanagement/i18n/MessageKeys.java
@@ -205,6 +205,8 @@ public abstract class MessageKeys {
       + ".cancellation.concurrentModification";
   public static final String ERROR_EVENT_LINE_ITEM_NOT_FOUND = EVENT_ERROR_PREFIX
       + ".lineItem.notFound";
+  public static final String ERROR_EVENT_LINE_ITEM_DUPLICATE = EVENT_ERROR_PREFIX
+      + ".lineItem.duplicate";
   public static final String ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE = EVENT_ERROR_PREFIX
       + ".lineItem.notCancellable";
   public static final String ERROR_EVENT_LINE_ITEM_ALREADY_CANCELLED = EVENT_ERROR_PREFIX

--- a/src/main/java/org/openlmis/stockmanagement/i18n/MessageKeys.java
+++ b/src/main/java/org/openlmis/stockmanagement/i18n/MessageKeys.java
@@ -198,6 +198,21 @@ public abstract class MessageKeys {
       + ".debit.quantity.exceed.stockOnHand";
   public static final String ERRRO_EVENT_SOH_EXCEEDS_LIMIT = EVENT_ERROR_PREFIX
       + ".stockOnHand.exceed.upperLimit";
+  //stock events cancellation
+  public static final String ERROR_EVENT_CANCELLATION_VALIDATION = EVENT_ERROR_PREFIX
+      + ".cancellation.validationFailed";
+  public static final String ERROR_EVENT_CANCELLATION_CONCURRENT_MODIFICATION = EVENT_ERROR_PREFIX
+      + ".cancellation.concurrentModification";
+  public static final String ERROR_EVENT_LINE_ITEM_NOT_FOUND = EVENT_ERROR_PREFIX
+      + ".lineItem.notFound";
+  public static final String ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE = EVENT_ERROR_PREFIX
+      + ".lineItem.notCancellable";
+  public static final String ERROR_EVENT_LINE_ITEM_ALREADY_CANCELLED = EVENT_ERROR_PREFIX
+      + ".lineItem.alreadyCancelled";
+  public static final String ERROR_EVENT_LINE_ITEM_IS_CANCELLATION = EVENT_ERROR_PREFIX
+      + ".lineItem.isCancellation";
+  public static final String ERROR_EVENT_LINE_ITEM_BLOCKED_PHYSICAL_INVENTORY = EVENT_ERROR_PREFIX
+      + ".lineItem.blocked.physicalInventory";
   //stock events creation: reason assignment
   //reason.not.in.validList error key is not used for now, because we remove valid reasons
   //check when implementing adjustment's UI

--- a/src/main/java/org/openlmis/stockmanagement/i18n/MessageKeys.java
+++ b/src/main/java/org/openlmis/stockmanagement/i18n/MessageKeys.java
@@ -205,6 +205,8 @@ public abstract class MessageKeys {
       + ".cancellation.concurrentModification";
   public static final String ERROR_EVENT_LINE_ITEM_NOT_FOUND = EVENT_ERROR_PREFIX
       + ".lineItem.notFound";
+  public static final String ERROR_EVENT_LINE_ITEM_MISSING_ID = EVENT_ERROR_PREFIX
+      + ".lineItem.missingId";
   public static final String ERROR_EVENT_LINE_ITEM_DUPLICATE = EVENT_ERROR_PREFIX
       + ".lineItem.duplicate";
   public static final String ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE = EVENT_ERROR_PREFIX

--- a/src/main/java/org/openlmis/stockmanagement/i18n/MessageKeys.java
+++ b/src/main/java/org/openlmis/stockmanagement/i18n/MessageKeys.java
@@ -213,6 +213,10 @@ public abstract class MessageKeys {
       + ".lineItem.isCancellation";
   public static final String ERROR_EVENT_LINE_ITEM_BLOCKED_PHYSICAL_INVENTORY = EVENT_ERROR_PREFIX
       + ".lineItem.blocked.physicalInventory";
+  public static final String ERROR_EVENT_CANCELLATION_REASON_REQUIRED = EVENT_ERROR_PREFIX
+      + ".cancellation.reason.required";
+  public static final String ERROR_EVENT_CANCELLATION_REASON_INVALID = EVENT_ERROR_PREFIX
+      + ".cancellation.reason.invalid";
   //stock events creation: reason assignment
   //reason.not.in.validList error key is not used for now, because we remove valid reasons
   //check when implementing adjustment's UI

--- a/src/main/java/org/openlmis/stockmanagement/repository/PhysicalInventoriesRepository.java
+++ b/src/main/java/org/openlmis/stockmanagement/repository/PhysicalInventoriesRepository.java
@@ -26,24 +26,30 @@ import org.springframework.data.repository.query.Param;
 public interface PhysicalInventoriesRepository
     extends PagingAndSortingRepository<PhysicalInventory, UUID> {
 
+  String PROGRAM_ID = "programId";
+  String FACILITY_ID = "facilityId";
+  String ORDERABLE_ID = "orderableId";
+  String OCCURRED_DATE = "occurredDate";
+
   List<PhysicalInventory> findByProgramIdAndFacilityIdAndIsDraft(
-      @Param("programId") UUID programId,
-      @Param("facilityId") UUID facilityId,
+      @Param(PROGRAM_ID) UUID programId,
+      @Param(FACILITY_ID) UUID facilityId,
       @Param("isDraft") boolean isDraft);
 
   List<PhysicalInventory> findByProgramIdAndFacilityId(
-      @Param("programId") UUID programId,
-      @Param("facilityId") UUID facilityId);
+      @Param(PROGRAM_ID) UUID programId,
+      @Param(FACILITY_ID) UUID facilityId);
 
   /**
    * Finds submitted physical inventories for the given facility, program, orderable and lot that
    * occurred after the given date. Used to block cancellation of a movement whose product and lot
-   * had a physical inventory recorded after it.
+   * had a physical inventory recorded after it. Kept separate from the no-lot variant so the
+   * {@code lotId} parameter is never bound as an untyped null (which Postgres rejects).
    *
    * @param programId    program id.
    * @param facilityId   facility id.
    * @param orderableId  orderable id.
-   * @param lotId        lot id, may be null.
+   * @param lotId        lot id, must not be null.
    * @param occurredDate the movement's occurred date; inventories strictly after it are returned.
    * @return the blocking submitted physical inventories.
    */
@@ -54,11 +60,34 @@ public interface PhysicalInventoriesRepository
       + " AND pi.isDraft = false"
       + " AND pi.occurredDate > :occurredDate"
       + " AND li.orderableId = :orderableId"
-      + " AND ((:lotId IS NULL AND li.lotId IS NULL) OR li.lotId = :lotId)")
-  List<PhysicalInventory> findSubmittedAfter(
-      @Param("programId") UUID programId,
-      @Param("facilityId") UUID facilityId,
-      @Param("orderableId") UUID orderableId,
+      + " AND li.lotId = :lotId")
+  List<PhysicalInventory> findSubmittedAfterForOrderableAndLot(
+      @Param(PROGRAM_ID) UUID programId,
+      @Param(FACILITY_ID) UUID facilityId,
+      @Param(ORDERABLE_ID) UUID orderableId,
       @Param("lotId") UUID lotId,
-      @Param("occurredDate") LocalDate occurredDate);
+      @Param(OCCURRED_DATE) LocalDate occurredDate);
+
+  /**
+   * Same as {@link #findSubmittedAfterForOrderableAndLot} but for line items without a lot.
+   *
+   * @param programId    program id.
+   * @param facilityId   facility id.
+   * @param orderableId  orderable id.
+   * @param occurredDate the movement's occurred date; inventories strictly after it are returned.
+   * @return the blocking submitted physical inventories.
+   */
+  @Query("SELECT DISTINCT pi FROM PhysicalInventory pi"
+      + " JOIN pi.lineItems li"
+      + " WHERE pi.programId = :programId"
+      + " AND pi.facilityId = :facilityId"
+      + " AND pi.isDraft = false"
+      + " AND pi.occurredDate > :occurredDate"
+      + " AND li.orderableId = :orderableId"
+      + " AND li.lotId IS NULL")
+  List<PhysicalInventory> findSubmittedAfterForOrderableWithoutLot(
+      @Param(PROGRAM_ID) UUID programId,
+      @Param(FACILITY_ID) UUID facilityId,
+      @Param(ORDERABLE_ID) UUID orderableId,
+      @Param(OCCURRED_DATE) LocalDate occurredDate);
 }

--- a/src/main/java/org/openlmis/stockmanagement/repository/PhysicalInventoriesRepository.java
+++ b/src/main/java/org/openlmis/stockmanagement/repository/PhysicalInventoriesRepository.java
@@ -16,6 +16,7 @@
 package org.openlmis.stockmanagement.repository;
 
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.openlmis.stockmanagement.domain.physicalinventory.PhysicalInventory;
@@ -30,6 +31,7 @@ public interface PhysicalInventoriesRepository
   String FACILITY_ID = "facilityId";
   String ORDERABLE_ID = "orderableId";
   String OCCURRED_DATE = "occurredDate";
+  String PROCESSED_DATE = "processedDate";
 
   List<PhysicalInventory> findByProgramIdAndFacilityIdAndIsDraft(
       @Param(PROGRAM_ID) UUID programId,
@@ -50,15 +52,19 @@ public interface PhysicalInventoriesRepository
    * @param facilityId   facility id.
    * @param orderableId  orderable id.
    * @param lotId        lot id, must not be null.
-   * @param occurredDate the movement's occurred date; inventories strictly after it are returned.
-   * @return the blocking submitted physical inventories.
+   * @param occurredDate the movement's occurred date.
+   * @param processedDate the movement's processed date; used as the tiebreaker on equal occurred
+   *                      dates, matching StockCard.getLineItemsComparator() ordering.
+   * @return the blocking submitted physical inventories (ordered after the movement).
    */
   @Query("SELECT DISTINCT pi FROM PhysicalInventory pi"
       + " JOIN pi.lineItems li"
+      + " LEFT JOIN pi.stockEvent se"
       + " WHERE pi.programId = :programId"
       + " AND pi.facilityId = :facilityId"
       + " AND pi.isDraft = false"
-      + " AND pi.occurredDate > :occurredDate"
+      + " AND (pi.occurredDate > :occurredDate"
+      + "   OR (pi.occurredDate = :occurredDate AND se.processedDate > :processedDate))"
       + " AND li.orderableId = :orderableId"
       + " AND li.lotId = :lotId")
   List<PhysicalInventory> findSubmittedAfterForOrderableAndLot(
@@ -66,7 +72,8 @@ public interface PhysicalInventoriesRepository
       @Param(FACILITY_ID) UUID facilityId,
       @Param(ORDERABLE_ID) UUID orderableId,
       @Param("lotId") UUID lotId,
-      @Param(OCCURRED_DATE) LocalDate occurredDate);
+      @Param(OCCURRED_DATE) LocalDate occurredDate,
+      @Param(PROCESSED_DATE) ZonedDateTime processedDate);
 
   /**
    * Same as {@link #findSubmittedAfterForOrderableAndLot} but for line items without a lot.
@@ -74,20 +81,25 @@ public interface PhysicalInventoriesRepository
    * @param programId    program id.
    * @param facilityId   facility id.
    * @param orderableId  orderable id.
-   * @param occurredDate the movement's occurred date; inventories strictly after it are returned.
-   * @return the blocking submitted physical inventories.
+   * @param occurredDate the movement's occurred date.
+   * @param processedDate the movement's processed date; used as the tiebreaker on equal occurred
+   *                      dates, matching StockCard.getLineItemsComparator() ordering.
+   * @return the blocking submitted physical inventories (ordered after the movement).
    */
   @Query("SELECT DISTINCT pi FROM PhysicalInventory pi"
       + " JOIN pi.lineItems li"
+      + " LEFT JOIN pi.stockEvent se"
       + " WHERE pi.programId = :programId"
       + " AND pi.facilityId = :facilityId"
       + " AND pi.isDraft = false"
-      + " AND pi.occurredDate > :occurredDate"
+      + " AND (pi.occurredDate > :occurredDate"
+      + "   OR (pi.occurredDate = :occurredDate AND se.processedDate > :processedDate))"
       + " AND li.orderableId = :orderableId"
       + " AND li.lotId IS NULL")
   List<PhysicalInventory> findSubmittedAfterForOrderableWithoutLot(
       @Param(PROGRAM_ID) UUID programId,
       @Param(FACILITY_ID) UUID facilityId,
       @Param(ORDERABLE_ID) UUID orderableId,
-      @Param(OCCURRED_DATE) LocalDate occurredDate);
+      @Param(OCCURRED_DATE) LocalDate occurredDate,
+      @Param(PROCESSED_DATE) ZonedDateTime processedDate);
 }

--- a/src/main/java/org/openlmis/stockmanagement/repository/PhysicalInventoriesRepository.java
+++ b/src/main/java/org/openlmis/stockmanagement/repository/PhysicalInventoriesRepository.java
@@ -15,9 +15,11 @@
 
 package org.openlmis.stockmanagement.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import org.openlmis.stockmanagement.domain.physicalinventory.PhysicalInventory;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 
@@ -32,4 +34,31 @@ public interface PhysicalInventoriesRepository
   List<PhysicalInventory> findByProgramIdAndFacilityId(
       @Param("programId") UUID programId,
       @Param("facilityId") UUID facilityId);
+
+  /**
+   * Finds submitted physical inventories for the given facility, program, orderable and lot that
+   * occurred after the given date. Used to block cancellation of a movement whose product and lot
+   * had a physical inventory recorded after it.
+   *
+   * @param programId    program id.
+   * @param facilityId   facility id.
+   * @param orderableId  orderable id.
+   * @param lotId        lot id, may be null.
+   * @param occurredDate the movement's occurred date; inventories strictly after it are returned.
+   * @return the blocking submitted physical inventories.
+   */
+  @Query("SELECT DISTINCT pi FROM PhysicalInventory pi"
+      + " JOIN pi.lineItems li"
+      + " WHERE pi.programId = :programId"
+      + " AND pi.facilityId = :facilityId"
+      + " AND pi.isDraft = false"
+      + " AND pi.occurredDate > :occurredDate"
+      + " AND li.orderableId = :orderableId"
+      + " AND ((:lotId IS NULL AND li.lotId IS NULL) OR li.lotId = :lotId)")
+  List<PhysicalInventory> findSubmittedAfter(
+      @Param("programId") UUID programId,
+      @Param("facilityId") UUID facilityId,
+      @Param("orderableId") UUID orderableId,
+      @Param("lotId") UUID lotId,
+      @Param("occurredDate") LocalDate occurredDate);
 }

--- a/src/main/java/org/openlmis/stockmanagement/repository/StockEventLineItemRepository.java
+++ b/src/main/java/org/openlmis/stockmanagement/repository/StockEventLineItemRepository.java
@@ -1,0 +1,35 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface StockEventLineItemRepository
+    extends PagingAndSortingRepository<StockEventLineItem, UUID> {
+
+  /**
+   * Returns the cancellation line items that reverse any of the given original line items. Used to
+   * detect which line items have already been cancelled.
+   *
+   * @param reversedLineItemIds ids of the original line items being checked.
+   * @return the cancellation line items pointing at any of the given ids.
+   */
+  List<StockEventLineItem> findByReversesEventLineItemIdIn(Collection<UUID> reversedLineItemIds);
+}

--- a/src/main/java/org/openlmis/stockmanagement/repository/StockEventLineItemRepository.java
+++ b/src/main/java/org/openlmis/stockmanagement/repository/StockEventLineItemRepository.java
@@ -32,4 +32,15 @@ public interface StockEventLineItemRepository
    * @return the cancellation line items pointing at any of the given ids.
    */
   List<StockEventLineItem> findByReversesEventLineItemIdIn(Collection<UUID> reversedLineItemIds);
+
+  /**
+   * Returns the cancellation line items (those that reverse another line) belonging to any of the
+   * given stock events. Used to detect which shown events are cancellations and which original
+   * line they reverse.
+   *
+   * @param stockEventIds ids of the stock events shown on the page.
+   * @return the cancellation line items of those events.
+   */
+  List<StockEventLineItem> findByStockEventIdInAndReversesEventLineItemIdIsNotNull(
+      Collection<UUID> stockEventIds);
 }

--- a/src/main/java/org/openlmis/stockmanagement/service/CancellationLinkResolver.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/CancellationLinkResolver.java
@@ -1,0 +1,144 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.service;
+
+import static java.util.Collections.emptyMap;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.openlmis.stockmanagement.domain.event.StockEvent;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.openlmis.stockmanagement.dto.StockCardLineItemDto;
+import org.openlmis.stockmanagement.repository.StockEventLineItemRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves, per page and read-side only, the cross-links between an issue/receive event and the
+ * event that cancelled it (resolved on read; the original event is left untouched):
+ * "Reversing" (a cancellation line links to the original event it reverses) and "Reversed by"
+ * (an original line links to the cancellation event that reversed it).
+ */
+@Service
+@RequiredArgsConstructor
+public class CancellationLinkResolver {
+
+  private final StockEventLineItemRepository stockEventLineItemRepository;
+
+  /**
+   * Sets both cancellation cross-links on the given stock card line item DTOs, in batch.
+   *
+   * @param lineItems the stock card line item DTOs shown on the current page.
+   */
+  public void attachCancellationLinks(List<StockCardLineItemDto> lineItems) {
+    if (lineItems == null || lineItems.isEmpty()) {
+      return;
+    }
+    attachReversing(lineItems);
+    attachReversedBy(lineItems);
+  }
+
+  // "Reversing": for a cancellation line, the original event it reverses (once per cancellation
+  // event, since a cancellation reverses exactly one original event).
+  private void attachReversing(List<StockCardLineItemDto> lineItems) {
+    Map<UUID, StockEvent> reversedByCancellationEvent = reversedEvents(lineItems);
+    for (StockCardLineItemDto lineItem : lineItems) {
+      StockEvent originEvent = originEventOf(lineItem);
+      StockEvent reversed = originEvent == null
+          ? null : reversedByCancellationEvent.get(originEvent.getId());
+      if (reversed != null) {
+        lineItem.setReversedEventId(reversed.getId());
+        lineItem.setReversedEventDocumentNumber(reversed.getDocumentNumber());
+      }
+    }
+  }
+
+  // "Reversed by": for an original line, the cancellation event that reversed it, keyed by the
+  // line's own stock event line item id - stable and unique, unlike an orderable+lot match - so a
+  // partial cancellation marks only the line that was actually cancelled.
+  private void attachReversedBy(List<StockCardLineItemDto> lineItems) {
+    Set<UUID> lineItemIds = new HashSet<>();
+    for (StockCardLineItemDto dto : lineItems) {
+      if (dto.getStockEventLineItemId() != null) {
+        lineItemIds.add(dto.getStockEventLineItemId());
+      }
+    }
+    if (lineItemIds.isEmpty()) {
+      return;
+    }
+    Map<UUID, StockEvent> cancellationByOriginLine = cancellationEventsByOriginLine(lineItemIds);
+    for (StockCardLineItemDto dto : lineItems) {
+      StockEvent cancellation = cancellationByOriginLine.get(dto.getStockEventLineItemId());
+      if (cancellation != null) {
+        dto.setCancellationEventId(cancellation.getId());
+        dto.setCancellationEventDocumentNumber(cancellation.getDocumentNumber());
+      }
+    }
+  }
+
+  // original line id -> the cancellation event that reverses it
+  private Map<UUID, StockEvent> cancellationEventsByOriginLine(Collection<UUID> originLineIds) {
+    Map<UUID, StockEvent> map = new HashMap<>();
+    for (StockEventLineItem cancellationLine :
+        stockEventLineItemRepository.findByReversesEventLineItemIdIn(originLineIds)) {
+      map.putIfAbsent(cancellationLine.getReversesEventLineItemId(),
+          cancellationLine.getStockEvent());
+    }
+    return map;
+  }
+
+  private Map<UUID, StockEvent> reversedEvents(List<StockCardLineItemDto> lineItems) {
+    Set<UUID> eventIds = new HashSet<>();
+    for (StockCardLineItemDto dto : lineItems) {
+      StockEvent originEvent = originEventOf(dto);
+      if (originEvent != null) {
+        eventIds.add(originEvent.getId());
+      }
+    }
+    if (eventIds.isEmpty()) {
+      return emptyMap();
+    }
+
+    Map<UUID, UUID> reversedLineByEvent = new HashMap<>();
+    for (StockEventLineItem cancellationLine : stockEventLineItemRepository
+        .findByStockEventIdInAndReversesEventLineItemIdIsNotNull(eventIds)) {
+      reversedLineByEvent.putIfAbsent(cancellationLine.getStockEvent().getId(),
+          cancellationLine.getReversesEventLineItemId());
+    }
+
+    Map<UUID, StockEvent> eventByOriginLine = new HashMap<>();
+    stockEventLineItemRepository.findAllById(reversedLineByEvent.values())
+        .forEach(line -> eventByOriginLine.put(line.getId(), line.getStockEvent()));
+
+    Map<UUID, StockEvent> result = new HashMap<>();
+    reversedLineByEvent.forEach((cancellationEventId, originLineId) -> {
+      StockEvent originEvent = eventByOriginLine.get(originLineId);
+      if (originEvent != null) {
+        result.put(cancellationEventId, originEvent);
+      }
+    });
+    return result;
+  }
+
+  private static StockEvent originEventOf(StockCardLineItemDto dto) {
+    return dto.getLineItem() == null ? null : dto.getLineItem().getOriginEvent();
+  }
+}

--- a/src/main/java/org/openlmis/stockmanagement/service/CancellationReasonResolver.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/CancellationReasonResolver.java
@@ -21,9 +21,12 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_INVALID;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_REQUIRED;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_VALIDATION;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -32,9 +35,9 @@ import lombok.RequiredArgsConstructor;
 import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
 import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
 import org.openlmis.stockmanagement.dto.StockEventCancelLineItemDto;
-import org.openlmis.stockmanagement.exception.ValidationMessageException;
+import org.openlmis.stockmanagement.dto.StockEventCancellationLineErrorDto;
+import org.openlmis.stockmanagement.exception.StockEventCancellationException;
 import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
-import org.openlmis.stockmanagement.util.Message;
 import org.springframework.stereotype.Service;
 
 /**
@@ -60,9 +63,18 @@ public class CancellationReasonResolver {
       Map<UUID, StockEventLineItem> originalById) {
     Map<UUID, StockCardLineItemReason> loaded = loadReasons(requested);
     Map<UUID, StockCardLineItemReason> resolved = new HashMap<>();
+    List<StockEventCancellationLineErrorDto> errors = new ArrayList<>();
     for (StockEventCancelLineItemDto line : requested) {
       StockEventLineItem original = originalById.get(line.getStockEventLineItemId());
-      resolved.put(line.getStockEventLineItemId(), validateReason(line, original, loaded));
+      StockCardLineItemReason reason = reasonOrError(line, original, loaded, errors);
+      if (reason != null) {
+        resolved.put(line.getStockEventLineItemId(), reason);
+      }
+    }
+    // Collect every bad reason and report them together, per line, in the same shape as the other
+    // cancellation checks (AC#9) - the client marks each blocking line rather than only the first.
+    if (!errors.isEmpty()) {
+      throw new StockEventCancellationException(ERROR_EVENT_CANCELLATION_VALIDATION, errors);
     }
     return resolved;
   }
@@ -80,22 +92,31 @@ public class CancellationReasonResolver {
         .collect(toMap(StockCardLineItemReason::getId, identity()));
   }
 
-  private StockCardLineItemReason validateReason(StockEventCancelLineItemDto requested,
-      StockEventLineItem original, Map<UUID, StockCardLineItemReason> reasonsById) {
+  // Returns the validated cancellation reason for the line, or null - recording a per-line error -
+  // when the reason is missing or is not a cancel-tagged ADJUSTMENT that counters the movement.
+  private StockCardLineItemReason reasonOrError(StockEventCancelLineItemDto requested,
+      StockEventLineItem original, Map<UUID, StockCardLineItemReason> reasonsById,
+      List<StockEventCancellationLineErrorDto> errors) {
     UUID reasonId = requested.getReasonId();
     if (reasonId == null) {
-      throw new ValidationMessageException(
-          new Message(ERROR_EVENT_CANCELLATION_REASON_REQUIRED, original.getId()));
+      errors.add(lineError(requested, ERROR_EVENT_CANCELLATION_REASON_REQUIRED));
+      return null;
     }
     StockCardLineItemReason reason = reasonsById.get(reasonId);
     if (reason == null
         || !reason.isAdjustmentReasonCategory()
         || !reason.getTags().contains(StockEventCancelValidationService.CANCEL_TAG)
         || !countersMovement(original, reason)) {
-      throw new ValidationMessageException(
-          new Message(ERROR_EVENT_CANCELLATION_REASON_INVALID, reasonId));
+      errors.add(lineError(requested, ERROR_EVENT_CANCELLATION_REASON_INVALID));
+      return null;
     }
     return reason;
+  }
+
+  private StockEventCancellationLineErrorDto lineError(StockEventCancelLineItemDto requested,
+      String messageKey) {
+    return new StockEventCancellationLineErrorDto(
+        requested.getStockEventLineItemId(), messageKey, null, null);
   }
 
   private boolean countersMovement(StockEventLineItem original, StockCardLineItemReason reason) {

--- a/src/main/java/org/openlmis/stockmanagement/service/CancellationReasonResolver.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/CancellationReasonResolver.java
@@ -1,0 +1,107 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.service;
+
+import static java.util.Collections.emptyMap;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_INVALID;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_REQUIRED;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
+import org.openlmis.stockmanagement.dto.StockEventCancelLineItemDto;
+import org.openlmis.stockmanagement.exception.ValidationMessageException;
+import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
+import org.openlmis.stockmanagement.util.Message;
+import org.springframework.stereotype.Service;
+
+/**
+ * Loads and validates the cancellation reason chosen for each line item selected for cancellation.
+ * A valid reason is a cancel-tagged ADJUSTMENT reason whose type counters the original movement: an
+ * issue is reversed with a credit, a receive with a debit.
+ */
+@Service
+@RequiredArgsConstructor
+public class CancellationReasonResolver {
+
+  private final StockCardLineItemReasonRepository reasonRepository;
+
+  /**
+   * Resolves the validated cancellation reason for each requested line item.
+   *
+   * @param requested    the line items selected for cancellation with their chosen reason.
+   * @param originalById the event's original line items keyed by id.
+   * @return the validated cancellation reason keyed by original line item id.
+   */
+  public Map<UUID, StockCardLineItemReason> resolve(
+      Collection<StockEventCancelLineItemDto> requested,
+      Map<UUID, StockEventLineItem> originalById) {
+    Map<UUID, StockCardLineItemReason> loaded = loadReasons(requested);
+    Map<UUID, StockCardLineItemReason> resolved = new HashMap<>();
+    for (StockEventCancelLineItemDto line : requested) {
+      StockEventLineItem original = originalById.get(line.getStockEventLineItemId());
+      resolved.put(line.getStockEventLineItemId(), validateReason(line, original, loaded));
+    }
+    return resolved;
+  }
+
+  private Map<UUID, StockCardLineItemReason> loadReasons(
+      Collection<StockEventCancelLineItemDto> requested) {
+    Set<UUID> reasonIds = requested.stream()
+        .map(StockEventCancelLineItemDto::getReasonId)
+        .filter(Objects::nonNull)
+        .collect(toSet());
+    if (reasonIds.isEmpty()) {
+      return emptyMap();
+    }
+    return reasonRepository.findByIdIn(reasonIds).stream()
+        .collect(toMap(StockCardLineItemReason::getId, identity()));
+  }
+
+  private StockCardLineItemReason validateReason(StockEventCancelLineItemDto requested,
+      StockEventLineItem original, Map<UUID, StockCardLineItemReason> reasonsById) {
+    UUID reasonId = requested.getReasonId();
+    if (reasonId == null) {
+      throw new ValidationMessageException(
+          new Message(ERROR_EVENT_CANCELLATION_REASON_REQUIRED, original.getId()));
+    }
+    StockCardLineItemReason reason = reasonsById.get(reasonId);
+    if (reason == null
+        || !reason.isAdjustmentReasonCategory()
+        || !reason.getTags().contains(StockEventCancelValidationService.CANCEL_TAG)
+        || !countersMovement(original, reason)) {
+      throw new ValidationMessageException(
+          new Message(ERROR_EVENT_CANCELLATION_REASON_INVALID, reasonId));
+    }
+    return reason;
+  }
+
+  private boolean countersMovement(StockEventLineItem original, StockCardLineItemReason reason) {
+    // an issue (has a destination) is reversed with a credit; a receive (has a source) with a debit
+    return original.isIssue()
+        ? reason.isCreditReasonType()
+        : reason.isDebitReasonType();
+  }
+}

--- a/src/main/java/org/openlmis/stockmanagement/service/PermissionService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/PermissionService.java
@@ -54,6 +54,7 @@ public class PermissionService {
 
   public static final String STOCK_INVENTORIES_EDIT = "STOCK_INVENTORIES_EDIT";
   public static final String STOCK_ADJUST = "STOCK_ADJUST";
+  public static final String STOCK_EVENTS_CANCEL = "STOCK_EVENTS_CANCEL";
 
   public static final String STOCK_CARDS_VIEW = "STOCK_CARDS_VIEW";
 
@@ -98,6 +99,16 @@ public class PermissionService {
    */
   public void canAdjustStock(UUID programId, UUID facilityId) {
     hasPermission(STOCK_ADJUST, programId, facilityId, null);
+  }
+
+  /**
+   * Checks if current user has permission to cancel a stock event.
+   *
+   * @param programId  program id.
+   * @param facilityId facility id.
+   */
+  public void canCancelStockEvent(UUID programId, UUID facilityId) {
+    hasPermission(STOCK_EVENTS_CANCEL, programId, facilityId, null);
   }
 
   /**

--- a/src/main/java/org/openlmis/stockmanagement/service/StockCardBaseService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockCardBaseService.java
@@ -56,7 +56,17 @@ public abstract class StockCardBaseService {
   @Autowired
   protected CalculatedStockOnHandService calculatedStockOnHandService;
 
+  @Autowired
+  private CancellationLinkResolver cancellationLinkResolver;
+
   protected List<StockCardDto> createDtos(List<StockCard> stockCards) {
+    return createDtos(stockCards, true);
+  }
+
+  // withCancellationLinks lets callers that discard the line items right after (the stock card
+  // summaries paths) skip cross-link resolution and its extra per-page queries.
+  protected List<StockCardDto> createDtos(List<StockCard> stockCards,
+      boolean withCancellationLinks) {
     if (stockCards.isEmpty()) {
       return emptyList();
     }
@@ -68,9 +78,18 @@ public abstract class StockCardBaseService {
     LOGGER.debug("Calling ref data to retrieve program info for card");
     ProgramDto program = programRefDataService.findOne(firstCard.getProgramId());
 
-    return stockCards.stream()
+    List<StockCardDto> dtos = stockCards.stream()
         .map(card -> cardToDto(facility, program, card))
         .collect(toList());
+
+    if (withCancellationLinks) {
+      cancellationLinkResolver.attachCancellationLinks(dtos.stream()
+          .filter(dto -> dto.getLineItems() != null)
+          .flatMap(dto -> dto.getLineItems().stream())
+          .collect(toList()));
+    }
+
+    return dtos;
   }
 
   private StockCardDto cardToDto(FacilityDto facility, ProgramDto program,

--- a/src/main/java/org/openlmis/stockmanagement/service/StockCardSummariesService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockCardSummariesService.java
@@ -265,7 +265,7 @@ public class StockCardSummariesService extends StockCardBaseService {
     List<StockCard> dummyCards = createDummyCards(programId, facilityId,
         orderableLotMap.values(),
         existingCardIdentities).collect(toList());
-    return loadOrderableLotUnitAndRemoveLineItems(createDtos(dummyCards), orderableLotMap);
+    return loadOrderableLotUnitAndRemoveLineItems(createDtos(dummyCards, false), orderableLotMap);
   }
 
   private List<StockCardDto> cardsToDtos(List<StockCard> cards) {
@@ -281,7 +281,7 @@ public class StockCardSummariesService extends StockCardBaseService {
         orderableLotsMapIds.stream().map(OrderableLotIdentity::getLotId).filter(Objects::nonNull)
             .collect(toSet())).stream().collect(toMap(LotDto::getId, identity()));
 
-    return createDtos(cards).stream().map(cardDto -> {
+    return createDtos(cards, false).stream().map(cardDto -> {
       cardDto.setOrderable(orderables.get(cardDto.getOrderableId()));
       cardDto.setLot(cardDto.getLotId() != null ? lots.get(cardDto.getLotId()) : null);
       cardDto.setLineItems(null);

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
@@ -15,21 +15,16 @@
 
 package org.openlmis.stockmanagement.service;
 
-import static java.util.Collections.emptyMap;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
-import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_INVALID;
-import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_REQUIRED;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_DUPLICATE;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_STOCK_EVENT_NOT_FOUND;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.openlmis.stockmanagement.domain.event.StockEvent;
@@ -41,7 +36,6 @@ import org.openlmis.stockmanagement.dto.StockEventDto;
 import org.openlmis.stockmanagement.dto.StockEventLineItemDto;
 import org.openlmis.stockmanagement.exception.ResourceNotFoundException;
 import org.openlmis.stockmanagement.exception.ValidationMessageException;
-import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
 import org.openlmis.stockmanagement.repository.StockEventsRepository;
 import org.openlmis.stockmanagement.util.Message;
 import org.springframework.stereotype.Service;
@@ -58,7 +52,7 @@ public class StockEventCancelService {
 
   private final StockEventsRepository stockEventsRepository;
   private final StockEventCancelValidationService cancelValidationService;
-  private final StockCardLineItemReasonRepository reasonRepository;
+  private final CancellationReasonResolver reasonResolver;
   private final StockEventProcessor stockEventProcessor;
   private final PermissionService permissionService;
 
@@ -76,8 +70,7 @@ public class StockEventCancelService {
 
     permissionService.canCancelStockEvent(event.getProgramId(), event.getFacilityId());
 
-    Map<UUID, StockEventCancelLineItemDto> requestByLineId = request.getLineItems().stream()
-        .collect(toMap(StockEventCancelLineItemDto::getStockEventLineItemId, identity()));
+    Map<UUID, StockEventCancelLineItemDto> requestByLineId = indexByLineItemId(request);
 
     cancelValidationService.validate(event, requestByLineId.keySet());
 
@@ -86,16 +79,29 @@ public class StockEventCancelService {
     return stockEventProcessor.process(cancellation);
   }
 
+  // Indexes the requested line items by id, rejecting a line item selected more than once.
+  private Map<UUID, StockEventCancelLineItemDto> indexByLineItemId(StockEventCancelDto request) {
+    Map<UUID, StockEventCancelLineItemDto> byId = new LinkedHashMap<>();
+    for (StockEventCancelLineItemDto line : request.getLineItems()) {
+      if (byId.putIfAbsent(line.getStockEventLineItemId(), line) != null) {
+        throw new ValidationMessageException(
+            new Message(ERROR_EVENT_LINE_ITEM_DUPLICATE, line.getStockEventLineItemId()));
+      }
+    }
+    return byId;
+  }
+
   private StockEventDto buildCancellationEvent(StockEvent event, String signature,
       Map<UUID, StockEventCancelLineItemDto> requestByLineId) {
     Map<UUID, StockEventLineItem> originalById = event.getLineItems().stream()
         .collect(toMap(StockEventLineItem::getId, identity()));
-    Map<UUID, StockCardLineItemReason> reasonsById = loadReasons(requestByLineId.values());
+    Map<UUID, StockCardLineItemReason> reasonsByLineId =
+        reasonResolver.resolve(requestByLineId.values(), originalById);
 
     List<StockEventLineItemDto> lineItems = new ArrayList<>();
     for (StockEventCancelLineItemDto requested : requestByLineId.values()) {
       StockEventLineItem original = originalById.get(requested.getStockEventLineItemId());
-      StockCardLineItemReason reason = resolveCancelReason(requested, original, reasonsById);
+      StockCardLineItemReason reason = reasonsByLineId.get(requested.getStockEventLineItemId());
       lineItems.add(StockEventLineItemDto.builder()
           .orderableId(original.getOrderableId())
           .lotId(original.getLotId())
@@ -114,43 +120,5 @@ public class StockEventCancelService {
     cancellation.setActive(true);
     cancellation.setLineItems(lineItems);
     return cancellation;
-  }
-
-  private Map<UUID, StockCardLineItemReason> loadReasons(
-      Collection<StockEventCancelLineItemDto> requested) {
-    Set<UUID> reasonIds = requested.stream()
-        .map(StockEventCancelLineItemDto::getReasonId)
-        .filter(Objects::nonNull)
-        .collect(toSet());
-    if (reasonIds.isEmpty()) {
-      return emptyMap();
-    }
-    return reasonRepository.findByIdIn(reasonIds).stream()
-        .collect(toMap(StockCardLineItemReason::getId, identity()));
-  }
-
-  private StockCardLineItemReason resolveCancelReason(StockEventCancelLineItemDto requested,
-      StockEventLineItem original, Map<UUID, StockCardLineItemReason> reasonsById) {
-    UUID reasonId = requested.getReasonId();
-    if (reasonId == null) {
-      throw new ValidationMessageException(
-          new Message(ERROR_EVENT_CANCELLATION_REASON_REQUIRED, original.getId()));
-    }
-    StockCardLineItemReason reason = reasonsById.get(reasonId);
-    if (reason == null
-        || !reason.isAdjustmentReasonCategory()
-        || !reason.getTags().contains(StockEventCancelValidationService.CANCEL_TAG)
-        || !countersMovement(original, reason)) {
-      throw new ValidationMessageException(
-          new Message(ERROR_EVENT_CANCELLATION_REASON_INVALID, reasonId));
-    }
-    return reason;
-  }
-
-  private boolean countersMovement(StockEventLineItem original, StockCardLineItemReason reason) {
-    // an issue (has a destination) is reversed with a credit; a receive (has a source) with a debit
-    return original.isIssue()
-        ? reason.isCreditReasonType()
-        : reason.isDebitReasonType();
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
@@ -60,6 +60,7 @@ public class StockEventCancelService {
   private final StockEventCancelValidationService cancelValidationService;
   private final StockCardLineItemReasonRepository reasonRepository;
   private final StockEventProcessor stockEventProcessor;
+  private final PermissionService permissionService;
 
   /**
    * Cancels the selected line items of the given event.
@@ -72,6 +73,8 @@ public class StockEventCancelService {
     StockEvent event = stockEventsRepository.findById(eventId)
         .orElseThrow(() -> new ResourceNotFoundException(
             new Message(ERROR_STOCK_EVENT_NOT_FOUND, eventId)));
+
+    permissionService.canCancelStockEvent(event.getProgramId(), event.getFacilityId());
 
     Map<UUID, StockEventCancelLineItemDto> requestByLineId = request.getLineItems().stream()
         .collect(toMap(StockEventCancelLineItemDto::getStockEventLineItemId, identity()));

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
@@ -149,7 +149,7 @@ public class StockEventCancelService {
 
   private boolean countersMovement(StockEventLineItem original, StockCardLineItemReason reason) {
     // an issue (has a destination) is reversed with a credit; a receive (has a source) with a debit
-    return original.getDestinationId() != null
+    return original.isIssue()
         ? reason.isCreditReasonType()
         : reason.isDebitReasonType();
   }

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
@@ -18,6 +18,7 @@ package org.openlmis.stockmanagement.service;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_DUPLICATE;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_MISSING_ID;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_STOCK_EVENT_NOT_FOUND;
 
 import java.time.LocalDate;
@@ -83,9 +84,15 @@ public class StockEventCancelService {
   private Map<UUID, StockEventCancelLineItemDto> indexByLineItemId(StockEventCancelDto request) {
     Map<UUID, StockEventCancelLineItemDto> byId = new LinkedHashMap<>();
     for (StockEventCancelLineItemDto line : request.getLineItems()) {
-      if (byId.putIfAbsent(line.getStockEventLineItemId(), line) != null) {
+      UUID lineItemId = line.getStockEventLineItemId();
+      if (lineItemId == null) {
+        // A movement recorded before the reversal feature has no stable line item id, so it
+        // cannot be targeted for cancellation; reject it explicitly rather than fail later.
+        throw new ValidationMessageException(new Message(ERROR_EVENT_LINE_ITEM_MISSING_ID));
+      }
+      if (byId.putIfAbsent(lineItemId, line) != null) {
         throw new ValidationMessageException(
-            new Message(ERROR_EVENT_LINE_ITEM_DUPLICATE, line.getStockEventLineItemId()));
+            new Message(ERROR_EVENT_LINE_ITEM_DUPLICATE, lineItemId));
       }
     }
     return byId;

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
@@ -1,0 +1,153 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.service;
+
+import static java.util.Collections.emptyMap;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_INVALID;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_REQUIRED;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_STOCK_EVENT_NOT_FOUND;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.openlmis.stockmanagement.domain.event.StockEvent;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
+import org.openlmis.stockmanagement.dto.StockEventCancelDto;
+import org.openlmis.stockmanagement.dto.StockEventCancelLineItemDto;
+import org.openlmis.stockmanagement.dto.StockEventDto;
+import org.openlmis.stockmanagement.dto.StockEventLineItemDto;
+import org.openlmis.stockmanagement.exception.ResourceNotFoundException;
+import org.openlmis.stockmanagement.exception.ValidationMessageException;
+import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
+import org.openlmis.stockmanagement.repository.StockEventsRepository;
+import org.openlmis.stockmanagement.util.Message;
+import org.springframework.stereotype.Service;
+
+/**
+ * Builds and persists the adjustment stock event that cancels selected issue/receive line items.
+ * The original event is left untouched; a cancelled issue is reversed with a credit and a cancelled
+ * receive with a debit. Processing is delegated to {@link StockEventProcessor} so the cancellation
+ * reuses the standard validation, persistence and stock-on-hand recalculation.
+ */
+@Service
+@RequiredArgsConstructor
+public class StockEventCancelService {
+
+  private final StockEventsRepository stockEventsRepository;
+  private final StockEventCancelValidationService cancelValidationService;
+  private final StockCardLineItemReasonRepository reasonRepository;
+  private final StockEventProcessor stockEventProcessor;
+
+  /**
+   * Cancels the selected line items of the given event.
+   *
+   * @param eventId the original stock event id.
+   * @param request the line items to cancel, their cancellation reasons and the signature.
+   * @return the id of the created cancellation stock event.
+   */
+  public UUID cancel(UUID eventId, StockEventCancelDto request) {
+    StockEvent event = stockEventsRepository.findById(eventId)
+        .orElseThrow(() -> new ResourceNotFoundException(
+            new Message(ERROR_STOCK_EVENT_NOT_FOUND, eventId)));
+
+    Map<UUID, StockEventCancelLineItemDto> requestByLineId = request.getLineItems().stream()
+        .collect(toMap(StockEventCancelLineItemDto::getStockEventLineItemId, identity()));
+
+    cancelValidationService.validate(event, requestByLineId.keySet());
+
+    StockEventDto cancellation =
+        buildCancellationEvent(event, request.getSignature(), requestByLineId);
+    return stockEventProcessor.process(cancellation);
+  }
+
+  private StockEventDto buildCancellationEvent(StockEvent event, String signature,
+      Map<UUID, StockEventCancelLineItemDto> requestByLineId) {
+    Map<UUID, StockEventLineItem> originalById = event.getLineItems().stream()
+        .collect(toMap(StockEventLineItem::getId, identity()));
+    Map<UUID, StockCardLineItemReason> reasonsById = loadReasons(requestByLineId.values());
+
+    List<StockEventLineItemDto> lineItems = new ArrayList<>();
+    for (StockEventCancelLineItemDto requested : requestByLineId.values()) {
+      StockEventLineItem original = originalById.get(requested.getStockEventLineItemId());
+      StockCardLineItemReason reason = resolveCancelReason(requested, original, reasonsById);
+      lineItems.add(StockEventLineItemDto.builder()
+          .orderableId(original.getOrderableId())
+          .lotId(original.getLotId())
+          .quantity(original.getQuantity())
+          .occurredDate(LocalDate.now())
+          .reasonId(reason.getId())
+          .reasonFreeText(requested.getReasonFreeText())
+          .reversesEventLineItemId(original.getId())
+          .build());
+    }
+
+    StockEventDto cancellation = new StockEventDto();
+    cancellation.setFacilityId(event.getFacilityId());
+    cancellation.setProgramId(event.getProgramId());
+    cancellation.setSignature(signature);
+    cancellation.setActive(true);
+    cancellation.setLineItems(lineItems);
+    return cancellation;
+  }
+
+  private Map<UUID, StockCardLineItemReason> loadReasons(
+      Collection<StockEventCancelLineItemDto> requested) {
+    Set<UUID> reasonIds = requested.stream()
+        .map(StockEventCancelLineItemDto::getReasonId)
+        .filter(Objects::nonNull)
+        .collect(toSet());
+    if (reasonIds.isEmpty()) {
+      return emptyMap();
+    }
+    return reasonRepository.findByIdIn(reasonIds).stream()
+        .collect(toMap(StockCardLineItemReason::getId, identity()));
+  }
+
+  private StockCardLineItemReason resolveCancelReason(StockEventCancelLineItemDto requested,
+      StockEventLineItem original, Map<UUID, StockCardLineItemReason> reasonsById) {
+    UUID reasonId = requested.getReasonId();
+    if (reasonId == null) {
+      throw new ValidationMessageException(
+          new Message(ERROR_EVENT_CANCELLATION_REASON_REQUIRED, original.getId()));
+    }
+    StockCardLineItemReason reason = reasonsById.get(reasonId);
+    if (reason == null
+        || !reason.isAdjustmentReasonCategory()
+        || !reason.getTags().contains(StockEventCancelValidationService.CANCEL_TAG)
+        || !countersMovement(original, reason)) {
+      throw new ValidationMessageException(
+          new Message(ERROR_EVENT_CANCELLATION_REASON_INVALID, reasonId));
+    }
+    return reason;
+  }
+
+  private boolean countersMovement(StockEventLineItem original, StockCardLineItemReason reason) {
+    // an issue (has a destination) is reversed with a credit; a receive (has a source) with a debit
+    return original.getDestinationId() != null
+        ? reason.isCreditReasonType()
+        : reason.isDebitReasonType();
+  }
+}

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
@@ -99,7 +99,7 @@ public class StockEventCancelValidationService {
     if (isCancellationReason(lineItem, cancelReasonIds)) {
       return lineError(lineItem, ERROR_EVENT_LINE_ITEM_IS_CANCELLATION, null);
     }
-    if (!isIssueOrReceive(lineItem)) {
+    if (!lineItem.isMovement()) {
       return lineError(lineItem, ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE, null);
     }
     if (alreadyCancelledIds.contains(lineItem.getId())) {
@@ -151,10 +151,6 @@ public class StockEventCancelValidationService {
 
   private boolean isCancellationReason(StockEventLineItem lineItem, Set<UUID> cancelReasonIds) {
     return lineItem.getReasonId() != null && cancelReasonIds.contains(lineItem.getReasonId());
-  }
-
-  private boolean isIssueOrReceive(StockEventLineItem lineItem) {
-    return lineItem.getSourceId() != null || lineItem.getDestinationId() != null;
   }
 
   private List<BlockingTransactionDto> findBlockingInventories(StockEvent event,

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
@@ -1,0 +1,176 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.service;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_VALIDATION;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_ALREADY_CANCELLED;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_BLOCKED_PHYSICAL_INVENTORY;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_IS_CANCELLATION;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_NOT_FOUND;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_NO_LINE_ITEMS;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.openlmis.stockmanagement.domain.event.StockEvent;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.openlmis.stockmanagement.domain.physicalinventory.PhysicalInventory;
+import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
+import org.openlmis.stockmanagement.dto.BlockingTransactionDto;
+import org.openlmis.stockmanagement.dto.StockEventCancellationLineErrorDto;
+import org.openlmis.stockmanagement.exception.StockEventCancellationException;
+import org.openlmis.stockmanagement.exception.ValidationMessageException;
+import org.openlmis.stockmanagement.repository.PhysicalInventoriesRepository;
+import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
+import org.openlmis.stockmanagement.repository.StockEventLineItemRepository;
+import org.openlmis.stockmanagement.util.Message;
+import org.springframework.stereotype.Service;
+
+/**
+ * Validates that selected line items of an issue/receive stock event may be cancelled. Every
+ * per-line failure is collected so the caller learns about all blocking line items at once.
+ */
+@Service
+@RequiredArgsConstructor
+public class StockEventCancelValidationService {
+
+  static final String CANCEL_TAG = "cancel";
+  static final String PHYSICAL_INVENTORY_TYPE = "PHYSICAL_INVENTORY";
+
+  private final StockEventLineItemRepository stockEventLineItemRepository;
+  private final PhysicalInventoriesRepository physicalInventoriesRepository;
+  private final StockCardLineItemReasonRepository reasonRepository;
+
+  /**
+   * Validates that the selected line items of the given event can be cancelled. Collects every
+   * per-line failure and, if any, throws a single {@link StockEventCancellationException}.
+   *
+   * @param event               the original stock event being cancelled.
+   * @param lineItemIdsToCancel ids of the event's line items selected for cancellation.
+   */
+  public void validate(StockEvent event, Collection<UUID> lineItemIdsToCancel) {
+    if (lineItemIdsToCancel == null || lineItemIdsToCancel.isEmpty()) {
+      throw new ValidationMessageException(new Message(ERROR_EVENT_NO_LINE_ITEMS, event.getId()));
+    }
+
+    List<StockEventLineItem> selected = resolveSelectedLineItems(event, lineItemIdsToCancel);
+    Set<UUID> alreadyCancelledIds = findAlreadyCancelledIds(lineItemIdsToCancel);
+    Set<UUID> cancelReasonIds = findCancelReasonIds(selected);
+
+    List<StockEventCancellationLineErrorDto> errors = new ArrayList<>();
+    for (StockEventLineItem lineItem : selected) {
+      StockEventCancellationLineErrorDto error =
+          validateLineItem(event, lineItem, alreadyCancelledIds, cancelReasonIds);
+      if (error != null) {
+        errors.add(error);
+      }
+    }
+
+    if (!errors.isEmpty()) {
+      throw new StockEventCancellationException(ERROR_EVENT_CANCELLATION_VALIDATION, errors);
+    }
+  }
+
+  private StockEventCancellationLineErrorDto validateLineItem(StockEvent event,
+      StockEventLineItem lineItem, Set<UUID> alreadyCancelledIds, Set<UUID> cancelReasonIds) {
+    if (isCancellationReason(lineItem, cancelReasonIds)) {
+      return lineError(lineItem, ERROR_EVENT_LINE_ITEM_IS_CANCELLATION, null);
+    }
+    if (!isIssueOrReceive(lineItem)) {
+      return lineError(lineItem, ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE, null);
+    }
+    if (alreadyCancelledIds.contains(lineItem.getId())) {
+      return lineError(lineItem, ERROR_EVENT_LINE_ITEM_ALREADY_CANCELLED, null);
+    }
+    List<BlockingTransactionDto> blocking = findBlockingInventories(event, lineItem);
+    if (!blocking.isEmpty()) {
+      return lineError(lineItem, ERROR_EVENT_LINE_ITEM_BLOCKED_PHYSICAL_INVENTORY, blocking);
+    }
+    return null;
+  }
+
+  private List<StockEventLineItem> resolveSelectedLineItems(StockEvent event,
+      Collection<UUID> lineItemIdsToCancel) {
+    Map<UUID, StockEventLineItem> byId = event.getLineItems().stream()
+        .collect(toMap(StockEventLineItem::getId, lineItem -> lineItem));
+    List<StockEventLineItem> selected = new ArrayList<>();
+    for (UUID id : lineItemIdsToCancel) {
+      StockEventLineItem lineItem = byId.get(id);
+      if (lineItem == null) {
+        throw new ValidationMessageException(
+            new Message(ERROR_EVENT_LINE_ITEM_NOT_FOUND, id, event.getId()));
+      }
+      selected.add(lineItem);
+    }
+    return selected;
+  }
+
+  private Set<UUID> findAlreadyCancelledIds(Collection<UUID> lineItemIdsToCancel) {
+    return stockEventLineItemRepository.findByReversesEventLineItemIdIn(lineItemIdsToCancel)
+        .stream()
+        .map(StockEventLineItem::getReversesEventLineItemId)
+        .collect(toSet());
+  }
+
+  private Set<UUID> findCancelReasonIds(List<StockEventLineItem> lineItems) {
+    Set<UUID> reasonIds = lineItems.stream()
+        .map(StockEventLineItem::getReasonId)
+        .filter(Objects::nonNull)
+        .collect(toSet());
+    if (reasonIds.isEmpty()) {
+      return emptySet();
+    }
+    return reasonRepository.findByIdIn(reasonIds).stream()
+        .filter(reason -> reason.getTags().contains(CANCEL_TAG))
+        .map(StockCardLineItemReason::getId)
+        .collect(toSet());
+  }
+
+  private boolean isCancellationReason(StockEventLineItem lineItem, Set<UUID> cancelReasonIds) {
+    return lineItem.getReasonId() != null && cancelReasonIds.contains(lineItem.getReasonId());
+  }
+
+  private boolean isIssueOrReceive(StockEventLineItem lineItem) {
+    return lineItem.getSourceId() != null || lineItem.getDestinationId() != null;
+  }
+
+  private List<BlockingTransactionDto> findBlockingInventories(StockEvent event,
+      StockEventLineItem lineItem) {
+    List<PhysicalInventory> inventories = physicalInventoriesRepository.findSubmittedAfter(
+        event.getProgramId(), event.getFacilityId(), lineItem.getOrderableId(),
+        lineItem.getLotId(), lineItem.getOccurredDate());
+    return inventories.stream()
+        .map(inventory -> new BlockingTransactionDto(
+            PHYSICAL_INVENTORY_TYPE, inventory.getOccurredDate(), inventory.getDocumentNumber()))
+        .collect(toList());
+  }
+
+  private StockEventCancellationLineErrorDto lineError(StockEventLineItem lineItem,
+      String messageKey, List<BlockingTransactionDto> blockingTransactions) {
+    return new StockEventCancellationLineErrorDto(
+        lineItem.getId(), messageKey, null, blockingTransactions);
+  }
+}

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
@@ -159,9 +159,13 @@ public class StockEventCancelValidationService {
 
   private List<BlockingTransactionDto> findBlockingInventories(StockEvent event,
       StockEventLineItem lineItem) {
-    List<PhysicalInventory> inventories = physicalInventoriesRepository.findSubmittedAfter(
-        event.getProgramId(), event.getFacilityId(), lineItem.getOrderableId(),
-        lineItem.getLotId(), lineItem.getOccurredDate());
+    List<PhysicalInventory> inventories = lineItem.getLotId() == null
+        ? physicalInventoriesRepository.findSubmittedAfterForOrderableWithoutLot(
+            event.getProgramId(), event.getFacilityId(), lineItem.getOrderableId(),
+            lineItem.getOccurredDate())
+        : physicalInventoriesRepository.findSubmittedAfterForOrderableAndLot(
+            event.getProgramId(), event.getFacilityId(), lineItem.getOrderableId(),
+            lineItem.getLotId(), lineItem.getOccurredDate());
     return inventories.stream()
         .map(inventory -> new BlockingTransactionDto(
             PHYSICAL_INVENTORY_TYPE, inventory.getOccurredDate(), inventory.getDocumentNumber()))

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
@@ -15,6 +15,7 @@
 
 package org.openlmis.stockmanagement.service;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -77,16 +78,16 @@ public class StockEventCancelValidationService {
     }
 
     List<StockEventLineItem> selected = resolveSelectedLineItems(event, lineItemIdsToCancel);
-    Set<UUID> alreadyCancelledIds = findAlreadyCancelledIds(lineItemIdsToCancel);
-    Set<UUID> cancelReasonIds = findCancelReasonIds(selected);
+    List<CancellationRule> rules = cancellationRules(event,
+        findAlreadyCancelledIds(lineItemIdsToCancel), findCancelReasonIds(selected));
 
     List<StockEventCancellationLineErrorDto> errors = new ArrayList<>();
     for (StockEventLineItem lineItem : selected) {
-      StockEventCancellationLineErrorDto error =
-          validateLineItem(event, lineItem, alreadyCancelledIds, cancelReasonIds);
-      if (error != null) {
-        errors.add(error);
-      }
+      rules.stream()
+          .map(rule -> rule.check(lineItem))
+          .filter(Objects::nonNull)
+          .findFirst()
+          .ifPresent(errors::add);
     }
 
     if (!errors.isEmpty()) {
@@ -94,22 +95,26 @@ public class StockEventCancelValidationService {
     }
   }
 
-  private StockEventCancellationLineErrorDto validateLineItem(StockEvent event,
-      StockEventLineItem lineItem, Set<UUID> alreadyCancelledIds, Set<UUID> cancelReasonIds) {
-    if (isCancellationReason(lineItem, cancelReasonIds)) {
-      return lineError(lineItem, ERROR_EVENT_LINE_ITEM_IS_CANCELLATION, null);
-    }
-    if (!lineItem.isMovement()) {
-      return lineError(lineItem, ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE, null);
-    }
-    if (alreadyCancelledIds.contains(lineItem.getId())) {
-      return lineError(lineItem, ERROR_EVENT_LINE_ITEM_ALREADY_CANCELLED, null);
-    }
+  // The ordered checks a line item must pass to be cancellable; the first failing one is reported.
+  // A new cancellation constraint is added here rather than by editing the validation loop.
+  private List<CancellationRule> cancellationRules(StockEvent event,
+      Set<UUID> alreadyCancelledIds, Set<UUID> cancelReasonIds) {
+    return asList(
+        lineItem -> isCancellationReason(lineItem, cancelReasonIds)
+            ? lineError(lineItem, ERROR_EVENT_LINE_ITEM_IS_CANCELLATION, null) : null,
+        lineItem -> !lineItem.isMovement()
+            ? lineError(lineItem, ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE, null) : null,
+        lineItem -> alreadyCancelledIds.contains(lineItem.getId())
+            ? lineError(lineItem, ERROR_EVENT_LINE_ITEM_ALREADY_CANCELLED, null) : null,
+        lineItem -> blockedByPhysicalInventory(event, lineItem));
+  }
+
+  private StockEventCancellationLineErrorDto blockedByPhysicalInventory(StockEvent event,
+      StockEventLineItem lineItem) {
     List<BlockingTransactionDto> blocking = findBlockingInventories(event, lineItem);
-    if (!blocking.isEmpty()) {
-      return lineError(lineItem, ERROR_EVENT_LINE_ITEM_BLOCKED_PHYSICAL_INVENTORY, blocking);
-    }
-    return null;
+    return blocking.isEmpty()
+        ? null
+        : lineError(lineItem, ERROR_EVENT_LINE_ITEM_BLOCKED_PHYSICAL_INVENTORY, blocking);
   }
 
   private List<StockEventLineItem> resolveSelectedLineItems(StockEvent event,
@@ -172,5 +177,11 @@ public class StockEventCancelValidationService {
       String messageKey, List<BlockingTransactionDto> blockingTransactions) {
     return new StockEventCancellationLineErrorDto(
         lineItem.getId(), messageKey, null, blockingTransactions);
+  }
+
+  // A single per-line cancellation check; returns an error, or null when the line passes.
+  @FunctionalInterface
+  private interface CancellationRule {
+    StockEventCancellationLineErrorDto check(StockEventLineItem lineItem);
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
@@ -28,6 +28,7 @@ import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITE
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_NOT_FOUND;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_NO_LINE_ITEMS;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -160,13 +161,18 @@ public class StockEventCancelValidationService {
 
   private List<BlockingTransactionDto> findBlockingInventories(StockEvent event,
       StockEventLineItem lineItem) {
+    // A physical inventory blocks cancellation when it is ordered after this movement on the stock
+    // card, which is (occurredDate, then processedDate) - see StockCard.getLineItemsComparator().
+    // Comparing occurredDate alone would miss a same-day inventory processed after the movement
+    // (which already reflects it), letting the reversal double-apply the quantity.
+    ZonedDateTime processedDate = event.getProcessedDate();
     List<PhysicalInventory> inventories = lineItem.getLotId() == null
         ? physicalInventoriesRepository.findSubmittedAfterForOrderableWithoutLot(
             event.getProgramId(), event.getFacilityId(), lineItem.getOrderableId(),
-            lineItem.getOccurredDate())
+            lineItem.getOccurredDate(), processedDate)
         : physicalInventoriesRepository.findSubmittedAfterForOrderableAndLot(
             event.getProgramId(), event.getFacilityId(), lineItem.getOrderableId(),
-            lineItem.getLotId(), lineItem.getOccurredDate());
+            lineItem.getLotId(), lineItem.getOccurredDate(), processedDate);
     return inventories.stream()
         .map(inventory -> new BlockingTransactionDto(
             PHYSICAL_INVENTORY_TYPE, inventory.getOccurredDate(), inventory.getDocumentNumber()))

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventProcessor.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventProcessor.java
@@ -18,14 +18,17 @@ package org.openlmis.stockmanagement.service;
 import static org.openlmis.stockmanagement.dto.PhysicalInventoryDto.fromEventDto;
 
 import java.sql.PreparedStatement;
+import java.util.List;
 import java.util.UUID;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
 import org.openlmis.stockmanagement.domain.event.StockEvent;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
 import org.openlmis.stockmanagement.dto.PhysicalInventoryDto;
 import org.openlmis.stockmanagement.dto.StockEventDto;
+import org.openlmis.stockmanagement.dto.StockEventLineItemDto;
 import org.openlmis.stockmanagement.extension.ExtensionManager;
 import org.openlmis.stockmanagement.extension.point.ExtensionPointId;
 import org.openlmis.stockmanagement.extension.point.StockEventPostProcessor;
@@ -134,8 +137,14 @@ public class StockEventProcessor {
     StockEvent stockEvent = eventDto.toEvent();
 
     profiler.start("DB_SAVE");
-    UUID savedEventId = stockEventsRepository.save(stockEvent).getId();
+    StockEvent savedEvent = stockEventsRepository.save(stockEvent);
+    UUID savedEventId = savedEvent.getId();
     LOGGER.debug("Saved stock event with id " + savedEventId);
+
+    // The persisted line items now have ids; copy them back onto the request dto in the order
+    // toEvent() created them (before sortEventDtos reorders it), so each generated stock card line
+    // item can record the stock event line item it originates from.
+    copyPersistedLineItemIds(eventDto, savedEvent);
 
     if (eventDto.isPhysicalInventory()) {
       profiler.start("CREATE_PHYSICAL_INVENTORY_DTO");
@@ -158,6 +167,26 @@ public class StockEventProcessor {
 
   private void sortEventDtos(StockEventDto eventDto) {
     eventDto.sortLineItemsByOccurreddate();
+  }
+
+  // toEvent() maps request line items to domain line items 1:1 in order, so after save the two
+  // lists line up by index (this runs before sortEventDtos reorders the request dto).
+  private void copyPersistedLineItemIds(StockEventDto eventDto, StockEvent savedEvent) {
+    List<StockEventLineItemDto> requestLines = eventDto.getLineItems();
+    List<StockEventLineItem> savedLines = savedEvent.getLineItems();
+    if (requestLines == null || savedLines == null || requestLines.size() != savedLines.size()) {
+      LOGGER.error(
+          "Could not copy persisted line item ids for stock event {}: request line count {} does "
+              + "not match persisted line count {}; generated stock card line items will have no "
+              + "origin line reference and the movement will not be cancellable",
+          savedEvent.getId(),
+          requestLines == null ? null : requestLines.size(),
+          savedLines == null ? null : savedLines.size());
+      return;
+    }
+    for (int i = 0; i < requestLines.size(); i++) {
+      requestLines.get(i).setId(savedLines.get(i).getId());
+    }
   }
 
   private void assignDocumentNumberIfNeeded(StockEventDto eventDto) {

--- a/src/main/java/org/openlmis/stockmanagement/web/StockEventsController.java
+++ b/src/main/java/org/openlmis/stockmanagement/web/StockEventsController.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.openlmis.stockmanagement.domain.event.EventOrigin;
+import org.openlmis.stockmanagement.dto.StockEventCancelDto;
 import org.openlmis.stockmanagement.dto.StockEventDto;
 import org.openlmis.stockmanagement.dto.StockEventHistoryDto;
 import org.openlmis.stockmanagement.dto.StockEventLineDetailDto;
@@ -33,6 +34,7 @@ import org.openlmis.stockmanagement.i18n.MessageKeys;
 import org.openlmis.stockmanagement.repository.custom.StockEventSearchParams;
 import org.openlmis.stockmanagement.service.HomeFacilityPermissionService;
 import org.openlmis.stockmanagement.service.PermissionService;
+import org.openlmis.stockmanagement.service.StockEventCancelService;
 import org.openlmis.stockmanagement.service.StockEventProcessor;
 import org.openlmis.stockmanagement.service.StockEventsService;
 import org.openlmis.stockmanagement.util.Message;
@@ -76,6 +78,9 @@ public class StockEventsController extends BaseController {
   @Autowired
   private StockEventsService stockEventsService;
 
+  @Autowired
+  private StockEventCancelService stockEventCancelService;
+
   /**
    * Create stock event.
    *
@@ -97,6 +102,24 @@ public class StockEventsController extends BaseController {
     ResponseEntity<UUID> response = new ResponseEntity<>(createdEventId, CREATED);
 
     return stopProfiler(profiler, response);
+  }
+
+  /**
+   * Cancel selected line items of an issue/receive stock event. Builds and persists an adjustment
+   * stock event that reverses them; the original event is left intact.
+   *
+   * @param id      the stock event whose line items are cancelled.
+   * @param request the line items to cancel with their cancellation reasons and the signature.
+   * @return the created cancellation stock event's id.
+   */
+  @RequestMapping(value = "stockEvents/{id}/cancel", method = POST)
+  public ResponseEntity<UUID> cancelStockEvent(
+      @PathVariable UUID id, @RequestBody StockEventCancelDto request) {
+    LOGGER.debug("Try to cancel stock event line items");
+
+    UUID cancellationEventId = stockEventCancelService.cancel(id, request);
+
+    return new ResponseEntity<>(cancellationEventId, CREATED);
   }
 
   /**

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -47,6 +47,8 @@ schemas:
   - stockCardTemplate: !include schemas/stockCardTemplate.json
   - stockEventDto: !include schemas/stockEventDto.json
   - stockEventLineItemDto: !include schemas/stockEventLineItemDto.json
+  - stockEventCancelDto: !include schemas/stockEventCancelDto.json
+  - stockEventCancellationError: !include schemas/stockEventCancellationError.json
   - stockEventExternalDto: !include schemas/stockEventExternalDto.json
   - stockEventLineItemExternalDto: !include schemas/stockEventLineItemExternalDto.json
   - stockEventHistoryDtoPage: !include schemas/stockEventHistoryDto.json
@@ -338,6 +340,34 @@ traits:
               body:
                 application/json:
                   schema: localizedMessage
+        /cancel:
+          post:
+            is: [ secured ]
+            description: Cancel selected issue/receive line items of the stock event. Requires the STOCK_EVENTS_CANCEL right for the event's facility and program. Creates a reversing adjustment stock event and recalculates stock on hand.
+            body:
+              application/json:
+                schema: stockEventCancelDto
+            responses:
+              201:
+                description: The cancellation stock event has been created.
+                body:
+                  application/json:
+                    schema: uuid
+              400:
+                description: One or more line items cannot be cancelled.
+                body:
+                  application/json:
+                    schema: stockEventCancellationError
+              403:
+                description: User does not have the STOCK_EVENTS_CANCEL permission for the facility and program.
+                body:
+                  application/json:
+                    schema: localizedMessage
+              404:
+                description: Stock event with the given id does not exist.
+                body:
+                  application/json:
+                    schema: localizedMessage
         /lineItems:
           get:
             is: [ secured, paginated ]

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -354,7 +354,7 @@ traits:
                   application/json:
                     schema: uuid
               400:
-                description: One or more line items cannot be cancelled.
+                description: Cancellation validation failed. Per-line eligibility failures (e.g. a physical inventory recorded after the movement, or an already-cancelled line) are listed in lineErrors; other failures (invalid request, cancellation reason, resulting negative stock on hand, or concurrent modification) return only the general message. lineErrors is optional, so both cases match this schema.
                 body:
                   application/json:
                     schema: stockEventCancellationError

--- a/src/main/resources/db/migration/20260722120000000__add_reverses_event_line_item_to_stock_event_line_items.sql
+++ b/src/main/resources/db/migration/20260722120000000__add_reverses_event_line_item_to_stock_event_line_items.sql
@@ -1,0 +1,15 @@
+-- Cancelling an Issue/Receive movement creates an ADJUSTMENT stock event whose line
+-- items point back to the reversed original line item via reverseseventlineitemid. This reference
+-- drives the line-level "cancelled" flag and partial cancellation. The partial unique index
+-- guarantees a given original line item can be reversed at most once (and also serves as the lookup
+-- index for the already-cancelled validation check).
+ALTER TABLE stockmanagement.stock_event_line_items
+    ADD COLUMN reverseseventlineitemid UUID;
+
+ALTER TABLE stockmanagement.stock_event_line_items
+    ADD FOREIGN KEY (reverseseventlineitemid)
+    REFERENCES stockmanagement.stock_event_line_items (id);
+
+CREATE UNIQUE INDEX stock_event_line_items_reverses_unique_idx
+    ON stockmanagement.stock_event_line_items (reverseseventlineitemid)
+    WHERE reverseseventlineitemid IS NOT NULL;

--- a/src/main/resources/db/migration/20260722130000000__add_cancel_adjustment_reasons.sql
+++ b/src/main/resources/db/migration/20260722130000000__add_cancel_adjustment_reasons.sql
@@ -1,0 +1,19 @@
+-- Reasons used to cancel Issue/Receive movements. A cancellation creates an ADJUSTMENT stock event
+-- whose line items use one of these reasons to counter the original movement: a cancelled Issue
+-- (a DEBIT that removed stock) is reversed with a CREDIT, and a cancelled Receive (a CREDIT that
+-- added stock) is reversed with a DEBIT. The 'cancel' tag marks them as usable only for
+-- cancellation and keeps them filtered out of the regular Issue/Receive/Adjust reason lists; they
+-- are intentionally not added to valid_reason_assignments.
+INSERT INTO stockmanagement.stock_card_line_item_reasons (
+    id, isfreetextallowed, name, reasoncategory, reasontype, description
+) VALUES
+    ('6997c774-2f91-4e36-8938-d3003fe2c203', 'true', 'Cancelled issue', 'ADJUSTMENT', 'CREDIT',
+        'Reverses a cancelled issue movement'),
+    ('46aa9d3e-0ce4-4138-b086-172cefb58360', 'true', 'Cancelled receipt', 'ADJUSTMENT', 'DEBIT',
+        'Reverses a cancelled receive movement');
+
+INSERT INTO stockmanagement.stock_card_line_item_reason_tags (
+    tag, reasonId
+) VALUES
+    ('cancel', '6997c774-2f91-4e36-8938-d3003fe2c203'),
+    ('cancel', '46aa9d3e-0ce4-4138-b086-172cefb58360');

--- a/src/main/resources/db/migration/20260730120000000__add_origin_event_line_item_to_stock_card_line_items.sql
+++ b/src/main/resources/db/migration/20260730120000000__add_origin_event_line_item_to_stock_card_line_items.sql
@@ -1,0 +1,10 @@
+-- Record, on each stock card line item, the stock event line item it was created from.
+-- This gives reads a stable, unique stockEventLineItemId - needed to cancel a specific line
+-- (partial cancellation) and to resolve the cancellation cross-links reliably, instead of a
+-- non-unique (event, orderable, lot) match. Nullable; populated for rows created going forward.
+ALTER TABLE stockmanagement.stock_card_line_items
+    ADD COLUMN origineventlineitemid UUID;
+
+ALTER TABLE stockmanagement.stock_card_line_items
+    ADD FOREIGN KEY (origineventlineitemid)
+    REFERENCES stockmanagement.stock_event_line_items (id);

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -50,6 +50,8 @@ stockmanagement.error.event.lineItem.notCancellable=Only issue or receive line i
 stockmanagement.error.event.lineItem.alreadyCancelled=This line item has already been cancelled.
 stockmanagement.error.event.lineItem.isCancellation=A cancellation line item cannot itself be cancelled.
 stockmanagement.error.event.lineItem.blocked.physicalInventory=This line item cannot be cancelled because a physical inventory was recorded after the movement for the same product and lot.
+stockmanagement.error.event.cancellation.reason.required=A cancellation reason is required for line item {0}.
+stockmanagement.error.event.cancellation.reason.invalid=Reason {0} is not a valid cancellation reason for this movement.
 #stock event creation: free text
 stockmanagement.error.event.sourceAndDestinationFreeText.bothPresent=Source free text "{0}" and destination free text "{1}" are both present.
 stockmanagement.error.event.sourceFreeText.notAllowed=Source {0} with free text "{1}" is not allowed.

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -46,6 +46,7 @@ stockmanagement.error.event.stockOnHand.exceed.upperLimit={0} plus {1} will make
 stockmanagement.error.event.cancellation.validationFailed=One or more line items cannot be cancelled. See the line item errors for details.
 stockmanagement.error.event.cancellation.concurrentModification=The stock data has changed since it was loaded. Please refresh and review the data before cancelling again.
 stockmanagement.error.event.lineItem.notFound=Line item {0} does not belong to stock event {1}.
+stockmanagement.error.event.lineItem.duplicate=Line item {0} is selected more than once for cancellation.
 stockmanagement.error.event.lineItem.notCancellable=Only issue or receive line items can be cancelled.
 stockmanagement.error.event.lineItem.alreadyCancelled=This line item has already been cancelled.
 stockmanagement.error.event.lineItem.isCancellation=A cancellation line item cannot itself be cancelled.

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -42,6 +42,14 @@ stockmanagement.error.event.reason.not.exist=Reason {0} does not exist.
 #stock event creation: debit quantity
 stockmanagement.error.event.debit.quantity.exceed.stockOnHand=An operation from {0} on product {1} would make the stock on hand below zero ({2} subtract {3}). Please review your stock card and the operation you are trying to perform.
 stockmanagement.error.event.stockOnHand.exceed.upperLimit={0} plus {1} will make stock on hand exceed integer's upper limit.
+#stock event cancellation
+stockmanagement.error.event.cancellation.validationFailed=One or more line items cannot be cancelled. See the line item errors for details.
+stockmanagement.error.event.cancellation.concurrentModification=The stock data has changed since it was loaded. Please refresh and review the data before cancelling again.
+stockmanagement.error.event.lineItem.notFound=Line item {0} does not belong to stock event {1}.
+stockmanagement.error.event.lineItem.notCancellable=Only issue or receive line items can be cancelled.
+stockmanagement.error.event.lineItem.alreadyCancelled=This line item has already been cancelled.
+stockmanagement.error.event.lineItem.isCancellation=A cancellation line item cannot itself be cancelled.
+stockmanagement.error.event.lineItem.blocked.physicalInventory=This line item cannot be cancelled because a physical inventory was recorded after the movement for the same product and lot.
 #stock event creation: free text
 stockmanagement.error.event.sourceAndDestinationFreeText.bothPresent=Source free text "{0}" and destination free text "{1}" are both present.
 stockmanagement.error.event.sourceFreeText.notAllowed=Source {0} with free text "{1}" is not allowed.

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -46,6 +46,7 @@ stockmanagement.error.event.stockOnHand.exceed.upperLimit={0} plus {1} will make
 stockmanagement.error.event.cancellation.validationFailed=One or more line items cannot be cancelled. See the line item errors for details.
 stockmanagement.error.event.cancellation.concurrentModification=The stock data has changed since it was loaded. Please refresh and review the data before cancelling again.
 stockmanagement.error.event.lineItem.notFound=Line item {0} does not belong to stock event {1}.
+stockmanagement.error.event.lineItem.missingId=A selected movement has no stable line item identifier and cannot be cancelled. Movements recorded before the reversal feature was introduced are not cancellable.
 stockmanagement.error.event.lineItem.duplicate=Line item {0} is selected more than once for cancellation.
 stockmanagement.error.event.lineItem.notCancellable=Only issue or receive line items can be cancelled.
 stockmanagement.error.event.lineItem.alreadyCancelled=This line item has already been cancelled.

--- a/src/main/resources/schemas/stockEventCancelDto.json
+++ b/src/main/resources/schemas/stockEventCancelDto.json
@@ -1,0 +1,36 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "StockEventCancelDto",
+  "description": "Request to cancel selected line items of an issue/receive stock event.",
+  "properties": {
+    "signature": {
+      "type": "string",
+      "description": "Signature of the user performing the cancellation."
+    },
+    "lineItems": {
+      "type": "array",
+      "title": "lineItems",
+      "items": {
+        "type": "object",
+        "title": "StockEventCancelLineItemDto",
+        "properties": {
+          "stockEventLineItemId": {
+            "type": "string",
+            "description": "Id of the original stock event line item to cancel."
+          },
+          "reasonId": {
+            "type": "string",
+            "description": "Id of the cancellation reason (a cancel-tagged adjustment reason)."
+          },
+          "reasonFreeText": {
+            "type": "string",
+            "description": "Optional free text for the cancellation reason."
+          }
+        },
+        "required": ["stockEventLineItemId", "reasonId"]
+      }
+    }
+  },
+  "required": ["lineItems"]
+}

--- a/src/main/resources/schemas/stockEventCancellationError.json
+++ b/src/main/resources/schemas/stockEventCancellationError.json
@@ -1,0 +1,61 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "StockEventCancellationError",
+  "description": "Error returned when one or more line items cannot be cancelled.",
+  "properties": {
+    "messageKey": {
+      "type": "string",
+      "description": "General message key for the cancellation failure."
+    },
+    "message": {
+      "type": "string",
+      "description": "General localized message for the cancellation failure."
+    },
+    "lineErrors": {
+      "type": "array",
+      "title": "lineErrors",
+      "items": {
+        "type": "object",
+        "title": "StockEventCancellationLineError",
+        "properties": {
+          "stockEventLineItemId": {
+            "type": "string",
+            "description": "Id of the line item that could not be cancelled."
+          },
+          "messageKey": {
+            "type": "string",
+            "description": "Message key describing why the line item is blocked."
+          },
+          "message": {
+            "type": "string",
+            "description": "Localized message describing why the line item is blocked."
+          },
+          "blockingTransactions": {
+            "type": "array",
+            "title": "blockingTransactions",
+            "items": {
+              "type": "object",
+              "title": "BlockingTransaction",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Type of the blocking transaction, e.g. PHYSICAL_INVENTORY."
+                },
+                "occurredDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "Occurred date of the blocking transaction."
+                },
+                "documentNumber": {
+                  "type": "string",
+                  "description": "Document number of the blocking transaction, if any."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/org/openlmis/stockmanagement/domain/event/StockEventLineItemTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/domain/event/StockEventLineItemTest.java
@@ -1,0 +1,58 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.domain.event;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+import org.junit.Test;
+
+public class StockEventLineItemTest {
+
+  @Test
+  public void issueShouldBeMovement() {
+    StockEventLineItem issue = StockEventLineItem.builder()
+        .destinationId(UUID.randomUUID())
+        .build();
+
+    assertTrue(issue.isIssue());
+    assertFalse(issue.isReceive());
+    assertTrue(issue.isMovement());
+  }
+
+  @Test
+  public void receiveShouldBeMovement() {
+    StockEventLineItem receive = StockEventLineItem.builder()
+        .sourceId(UUID.randomUUID())
+        .build();
+
+    assertFalse(receive.isIssue());
+    assertTrue(receive.isReceive());
+    assertTrue(receive.isMovement());
+  }
+
+  @Test
+  public void adjustmentShouldBeNeitherIssueNorReceive() {
+    StockEventLineItem adjustment = StockEventLineItem.builder()
+        .reasonId(UUID.randomUUID())
+        .build();
+
+    assertFalse(adjustment.isIssue());
+    assertFalse(adjustment.isReceive());
+    assertFalse(adjustment.isMovement());
+  }
+}

--- a/src/test/java/org/openlmis/stockmanagement/dto/StockEventLineItemDtoTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/dto/StockEventLineItemDtoTest.java
@@ -18,9 +18,11 @@ package org.openlmis.stockmanagement.dto;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.UUID;
 import org.junit.Test;
 import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
 import org.openlmis.stockmanagement.testutils.StockEventDtoDataBuilder;
+import org.openlmis.stockmanagement.testutils.StockEventLineItemDtoDataBuilder;
 
 public class StockEventLineItemDtoTest {
   @Test
@@ -41,6 +43,21 @@ public class StockEventLineItemDtoTest {
     assertThat(lineItem.getDestinationId(), is(lineItemDto.getDestinationId()));
     assertThat(lineItem.getSourceFreeText(), is(lineItemDto.getSourceFreeText()));
     assertThat(lineItem.getDestinationFreeText(), is(lineItemDto.getDestinationFreeText()));
+  }
+
+  @Test
+  public void shouldConvertReversesEventLineItemIdFromDtoToJpaModel() throws Exception {
+    //given
+    UUID reversedLineItemId = UUID.randomUUID();
+    StockEventLineItemDto lineItemDto = new StockEventLineItemDtoDataBuilder()
+        .withReversesEventLineItemId(reversedLineItemId)
+        .build();
+
+    //when
+    StockEventLineItem lineItem = lineItemDto.toEventLineItem();
+
+    //then
+    assertThat(lineItem.getReversesEventLineItemId(), is(reversedLineItemId));
   }
 
 }

--- a/src/test/java/org/openlmis/stockmanagement/errorhandling/GlobalErrorHandlingTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/errorhandling/GlobalErrorHandlingTest.java
@@ -17,6 +17,7 @@ package org.openlmis.stockmanagement.errorhandling;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_CONCURRENT_MODIFICATION;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_LINE_ITEM_REASON_TAGS_INVALID;
 
 import java.sql.SQLException;
@@ -54,6 +55,21 @@ public class GlobalErrorHandlingTest {
             new SQLException("sql error", "22001", new NullPointerException(MESSAGE))));
 
     Message.LocalizedMessage message = globalErrorHandling.handleJpaSystemException(ex);
+    assertEquals(translatedMessage, message);
+  }
+
+  @Test
+  public void shouldMapReversesUniqueViolationToConcurrentModification() {
+    Message.LocalizedMessage translatedMessage =
+        new Message(ERROR_EVENT_CANCELLATION_CONCURRENT_MODIFICATION).new LocalizedMessage("msg");
+    when(messageService.localize(new Message(ERROR_EVENT_CANCELLATION_CONCURRENT_MODIFICATION)))
+        .thenReturn(translatedMessage);
+    SQLException sql = new SQLException(
+        "violates unique constraint \"stock_event_line_items_reverses_unique_idx\"", "23505");
+    JpaSystemException ex = new JpaSystemException(new PersistenceException(sql));
+
+    Message.LocalizedMessage message = globalErrorHandling.handleJpaSystemException(ex);
+
     assertEquals(translatedMessage, message);
   }
 

--- a/src/test/java/org/openlmis/stockmanagement/service/CancellationLinkResolverTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/CancellationLinkResolverTest.java
@@ -1,0 +1,123 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.service;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openlmis.stockmanagement.domain.card.StockCardLineItem;
+import org.openlmis.stockmanagement.domain.event.StockEvent;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.openlmis.stockmanagement.dto.StockCardLineItemDto;
+import org.openlmis.stockmanagement.repository.StockEventLineItemRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CancellationLinkResolverTest {
+
+  @Mock
+  private StockEventLineItemRepository stockEventLineItemRepository;
+
+  @InjectMocks
+  private CancellationLinkResolver resolver;
+
+  @Test
+  public void shouldAttachReversingLinkForCancellationLine() {
+    StockEvent originEvent = event("DOC-ORIGIN");
+    StockEventLineItem originLine = line(originEvent, null);
+    StockEvent cancellationEvent = event("DOC-CANCEL");
+    StockEventLineItem cancellationLine = line(cancellationEvent, originLine.getId());
+    StockCardLineItemDto dto = cancellationDto(cancellationEvent);
+
+    when(stockEventLineItemRepository
+        .findByStockEventIdInAndReversesEventLineItemIdIsNotNull(any()))
+        .thenReturn(singletonList(cancellationLine));
+    when(stockEventLineItemRepository.findAllById(any()))
+        .thenReturn(singletonList(originLine));
+
+    resolver.attachCancellationLinks(singletonList(dto));
+
+    assertEquals(originEvent.getId(), dto.getReversedEventId());
+    assertEquals("DOC-ORIGIN", dto.getReversedEventDocumentNumber());
+  }
+
+  @Test
+  public void shouldAttachReversedByLinkForCancelledOriginLine() {
+    StockEvent originEvent = event("DOC-ORIGIN");
+    UUID originLineId = UUID.randomUUID();
+    StockEvent cancellationEvent = event("DOC-CANCEL");
+    StockEventLineItem cancellationLine = line(cancellationEvent, originLineId);
+    StockCardLineItemDto dto = originDto(originEvent, originLineId);
+
+    when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(any()))
+        .thenReturn(singletonList(cancellationLine));
+
+    resolver.attachCancellationLinks(singletonList(dto));
+
+    assertEquals(cancellationEvent.getId(), dto.getCancellationEventId());
+    assertEquals("DOC-CANCEL", dto.getCancellationEventDocumentNumber());
+  }
+
+  @Test
+  public void shouldNotAttachWhenEventIsNotCancellation() {
+    StockCardLineItemDto dto = cancellationDto(event("DOC-1"));
+    when(stockEventLineItemRepository
+        .findByStockEventIdInAndReversesEventLineItemIdIsNotNull(any()))
+        .thenReturn(emptyList());
+
+    resolver.attachCancellationLinks(singletonList(dto));
+
+    assertNull(dto.getReversedEventId());
+    assertNull(dto.getCancellationEventId());
+  }
+
+  private StockEvent event(String documentNumber) {
+    StockEvent event = new StockEvent();
+    event.setId(UUID.randomUUID());
+    event.setDocumentNumber(documentNumber);
+    return event;
+  }
+
+  private StockEventLineItem line(StockEvent stockEvent, UUID reversesEventLineItemId) {
+    StockEventLineItem line = new StockEventLineItem();
+    line.setId(UUID.randomUUID());
+    line.setStockEvent(stockEvent);
+    line.setReversesEventLineItemId(reversesEventLineItemId);
+    return line;
+  }
+
+  private StockCardLineItemDto cancellationDto(StockEvent originEvent) {
+    StockCardLineItem cardLine = StockCardLineItem.builder().originEvent(originEvent).build();
+    return StockCardLineItemDto.builder().lineItem(cardLine).build();
+  }
+
+  private StockCardLineItemDto originDto(StockEvent originEvent, UUID stockEventLineItemId) {
+    StockCardLineItem cardLine = StockCardLineItem.builder().originEvent(originEvent).build();
+    return StockCardLineItemDto.builder()
+        .lineItem(cardLine)
+        .stockEventLineItemId(stockEventLineItemId)
+        .build();
+  }
+}

--- a/src/test/java/org/openlmis/stockmanagement/service/CancellationReasonResolverTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/CancellationReasonResolverTest.java
@@ -1,0 +1,114 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.service;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.when;
+import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_TAG;
+
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.openlmis.stockmanagement.domain.reason.ReasonCategory;
+import org.openlmis.stockmanagement.domain.reason.ReasonType;
+import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
+import org.openlmis.stockmanagement.dto.StockEventCancelLineItemDto;
+import org.openlmis.stockmanagement.exception.ValidationMessageException;
+import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CancellationReasonResolverTest {
+
+  @Mock
+  private StockCardLineItemReasonRepository reasonRepository;
+
+  @InjectMocks
+  private CancellationReasonResolver resolver;
+
+  @Test
+  public void shouldResolveReasonThatCountersIssue() {
+    StockEventLineItem issue = issueLineItem();
+    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_TAG);
+    when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
+
+    Map<UUID, StockCardLineItemReason> resolved =
+        resolver.resolve(singletonList(requested(issue.getId(), reason.getId())),
+            singletonMap(issue.getId(), issue));
+
+    assertEquals(reason, resolved.get(issue.getId()));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowWhenReasonIsMissing() {
+    StockEventLineItem issue = issueLineItem();
+
+    resolver.resolve(singletonList(requested(issue.getId(), null)),
+        singletonMap(issue.getId(), issue));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowWhenReasonIsNotCancelTagged() {
+    StockEventLineItem issue = issueLineItem();
+    StockCardLineItemReason reason = reason(ReasonType.CREDIT);
+    when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
+
+    resolver.resolve(singletonList(requested(issue.getId(), reason.getId())),
+        singletonMap(issue.getId(), issue));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowWhenReasonTypeDoesNotCounterMovement() {
+    StockEventLineItem issue = issueLineItem();
+    StockCardLineItemReason reason = reason(ReasonType.DEBIT, CANCEL_TAG);
+    when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
+
+    resolver.resolve(singletonList(requested(issue.getId(), reason.getId())),
+        singletonMap(issue.getId(), issue));
+  }
+
+  private StockEventLineItem issueLineItem() {
+    StockEventLineItem lineItem = StockEventLineItem.builder()
+        .orderableId(UUID.randomUUID())
+        .destinationId(UUID.randomUUID())
+        .build();
+    lineItem.setId(UUID.randomUUID());
+    return lineItem;
+  }
+
+  private StockCardLineItemReason reason(ReasonType type, String... tags) {
+    StockCardLineItemReason reason = StockCardLineItemReason.builder()
+        .name("Cancellation " + type)
+        .reasonType(type)
+        .reasonCategory(ReasonCategory.ADJUSTMENT)
+        .tags(asList(tags))
+        .build();
+    reason.setId(UUID.randomUUID());
+    return reason;
+  }
+
+  private StockEventCancelLineItemDto requested(UUID lineItemId, UUID reasonId) {
+    return new StockEventCancelLineItemDto(lineItemId, reasonId, null);
+  }
+}

--- a/src/test/java/org/openlmis/stockmanagement/service/CancellationReasonResolverTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/CancellationReasonResolverTest.java
@@ -18,11 +18,16 @@ package org.openlmis.stockmanagement.service;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_INVALID;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_REQUIRED;
 import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_TAG;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.Test;
@@ -35,7 +40,8 @@ import org.openlmis.stockmanagement.domain.reason.ReasonCategory;
 import org.openlmis.stockmanagement.domain.reason.ReasonType;
 import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
 import org.openlmis.stockmanagement.dto.StockEventCancelLineItemDto;
-import org.openlmis.stockmanagement.exception.ValidationMessageException;
+import org.openlmis.stockmanagement.dto.StockEventCancellationLineErrorDto;
+import org.openlmis.stockmanagement.exception.StockEventCancellationException;
 import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -60,7 +66,7 @@ public class CancellationReasonResolverTest {
     assertEquals(reason, resolved.get(issue.getId()));
   }
 
-  @Test(expected = ValidationMessageException.class)
+  @Test(expected = StockEventCancellationException.class)
   public void shouldThrowWhenReasonIsMissing() {
     StockEventLineItem issue = issueLineItem();
 
@@ -68,7 +74,7 @@ public class CancellationReasonResolverTest {
         singletonMap(issue.getId(), issue));
   }
 
-  @Test(expected = ValidationMessageException.class)
+  @Test(expected = StockEventCancellationException.class)
   public void shouldThrowWhenReasonIsNotCancelTagged() {
     StockEventLineItem issue = issueLineItem();
     StockCardLineItemReason reason = reason(ReasonType.CREDIT);
@@ -78,7 +84,7 @@ public class CancellationReasonResolverTest {
         singletonMap(issue.getId(), issue));
   }
 
-  @Test(expected = ValidationMessageException.class)
+  @Test(expected = StockEventCancellationException.class)
   public void shouldThrowWhenReasonTypeDoesNotCounterMovement() {
     StockEventLineItem issue = issueLineItem();
     StockCardLineItemReason reason = reason(ReasonType.DEBIT, CANCEL_TAG);
@@ -86,6 +92,35 @@ public class CancellationReasonResolverTest {
 
     resolver.resolve(singletonList(requested(issue.getId(), reason.getId())),
         singletonMap(issue.getId(), issue));
+  }
+
+  @Test
+  public void shouldCollectEveryBadReasonAsAPerLineError() {
+    StockEventLineItem missingReason = issueLineItem();
+    StockEventLineItem wrongType = issueLineItem();
+    StockCardLineItemReason debit = reason(ReasonType.DEBIT, CANCEL_TAG);
+    when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(debit));
+
+    Map<UUID, StockEventLineItem> originals = new HashMap<>();
+    originals.put(missingReason.getId(), missingReason);
+    originals.put(wrongType.getId(), wrongType);
+
+    try {
+      resolver.resolve(
+          asList(requested(missingReason.getId(), null),
+              requested(wrongType.getId(), debit.getId())),
+          originals);
+      fail("expected StockEventCancellationException");
+    } catch (StockEventCancellationException ex) {
+      assertEquals(2, ex.getLineErrors().size());
+      Map<UUID, String> messageKeyByLine = ex.getLineErrors().stream()
+          .collect(toMap(StockEventCancellationLineErrorDto::getStockEventLineItemId,
+              StockEventCancellationLineErrorDto::getMessageKey));
+      assertEquals(ERROR_EVENT_CANCELLATION_REASON_REQUIRED,
+          messageKeyByLine.get(missingReason.getId()));
+      assertEquals(ERROR_EVENT_CANCELLATION_REASON_INVALID,
+          messageKeyByLine.get(wrongType.getId()));
+    }
   }
 
   private StockEventLineItem issueLineItem() {

--- a/src/test/java/org/openlmis/stockmanagement/service/PermissionServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/PermissionServiceTest.java
@@ -34,6 +34,7 @@ import static org.openlmis.stockmanagement.service.PermissionService.STOCK_ADJUS
 import static org.openlmis.stockmanagement.service.PermissionService.STOCK_CARDS_VIEW;
 import static org.openlmis.stockmanagement.service.PermissionService.STOCK_CARD_TEMPLATES_MANAGE;
 import static org.openlmis.stockmanagement.service.PermissionService.STOCK_DESTINATIONS_MANAGE;
+import static org.openlmis.stockmanagement.service.PermissionService.STOCK_EVENTS_CANCEL;
 import static org.openlmis.stockmanagement.service.PermissionService.STOCK_INVENTORIES_EDIT;
 import static org.openlmis.stockmanagement.service.PermissionService.STOCK_ORGANIZATIONS_MANAGE;
 import static org.openlmis.stockmanagement.service.PermissionService.STOCK_SOURCES_MANAGE;
@@ -195,6 +196,23 @@ public class PermissionServiceTest {
   }
 
   @Test
+  public void canCancelStockEvent() {
+    hasRight(rightId, programId, facilityId, true);
+
+    permissionService.canCancelStockEvent(programId, facilityId);
+
+    verifyUserRight(STOCK_EVENTS_CANCEL, rightId, programId, facilityId);
+  }
+
+  @Test
+  public void cannotCancelStockEvent() {
+    expectException(STOCK_EVENTS_CANCEL);
+    hasRight(rightId, programId, facilityId, false);
+
+    permissionService.canCancelStockEvent(programId, facilityId);
+  }
+
+  @Test
   public void canViewStockCard() {
     hasRight(rightId, programId, facilityId, true);
 
@@ -303,6 +321,7 @@ public class PermissionServiceTest {
     permissionService.canCreateStockCardTemplate();
     permissionService.canEditPhysicalInventory(programId, facilityId);
     permissionService.canAdjustStock(programId, facilityId);
+    permissionService.canCancelStockEvent(programId, facilityId);
     permissionService.canViewStockCard(programId, facilityId);
     permissionService.canManageStockSources();
     permissionService.canManageStockDestinations();

--- a/src/test/java/org/openlmis/stockmanagement/service/StockCardServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockCardServiceTest.java
@@ -85,6 +85,11 @@ public class StockCardServiceTest {
   @Mock
   private PermissionService permissionService;
 
+  @Mock
+  // injected into StockCardBaseService via @InjectMocks; not referenced directly in this test
+  @SuppressWarnings("PMD.UnusedPrivateField")
+  private CancellationLinkResolver cancellationLinkResolver;
+
   @InjectMocks
   private StockCardService stockCardService;
 

--- a/src/test/java/org/openlmis/stockmanagement/service/StockCardSummariesServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockCardSummariesServiceTest.java
@@ -130,6 +130,11 @@ public class StockCardSummariesServiceTest {
   private CalculatedStockOnHandRepository calculatedStockOnHandRepository;
   @Mock
   private HomeFacilityPermissionService homeFacilityPermissionService;
+  @Mock
+  // injected into StockCardBaseService via @InjectMocks; not referenced directly in this test
+  @SuppressWarnings("PMD.UnusedPrivateField")
+  private CancellationLinkResolver cancellationLinkResolver;
+
   @InjectMocks
   private StockCardSummariesService stockCardSummariesService;
 

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
@@ -1,0 +1,177 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.service;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_TAG;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openlmis.stockmanagement.domain.event.StockEvent;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.openlmis.stockmanagement.domain.reason.ReasonCategory;
+import org.openlmis.stockmanagement.domain.reason.ReasonType;
+import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
+import org.openlmis.stockmanagement.dto.StockEventCancelDto;
+import org.openlmis.stockmanagement.dto.StockEventCancelLineItemDto;
+import org.openlmis.stockmanagement.dto.StockEventDto;
+import org.openlmis.stockmanagement.dto.StockEventLineItemDto;
+import org.openlmis.stockmanagement.exception.ResourceNotFoundException;
+import org.openlmis.stockmanagement.exception.ValidationMessageException;
+import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
+import org.openlmis.stockmanagement.repository.StockEventsRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StockEventCancelServiceTest {
+
+  @Mock
+  private StockEventsRepository stockEventsRepository;
+
+  @Mock
+  private StockEventCancelValidationService cancelValidationService;
+
+  @Mock
+  private StockCardLineItemReasonRepository reasonRepository;
+
+  @Mock
+  private StockEventProcessor stockEventProcessor;
+
+  @InjectMocks
+  private StockEventCancelService service;
+
+  private final UUID eventId = UUID.randomUUID();
+  private final UUID facilityId = UUID.randomUUID();
+  private final UUID programId = UUID.randomUUID();
+
+  @Test
+  public void shouldBuildAndProcessCancellationEvent() {
+    StockEvent event = eventWithIssueLine();
+    StockEventLineItem original = event.getLineItems().get(0);
+    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_TAG);
+    StockEventCancelDto request = requestFor(original.getId(), reason.getId());
+    UUID newEventId = UUID.randomUUID();
+    ArgumentCaptor<StockEventDto> captor = ArgumentCaptor.forClass(StockEventDto.class);
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
+    when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
+    when(stockEventProcessor.process(captor.capture())).thenReturn(newEventId);
+
+    UUID result = service.cancel(eventId, request);
+
+    assertEquals(newEventId, result);
+    verify(cancelValidationService).validate(eq(event), any());
+    StockEventDto cancellation = captor.getValue();
+    assertEquals(facilityId, cancellation.getFacilityId());
+    assertEquals(programId, cancellation.getProgramId());
+    assertEquals("signature", cancellation.getSignature());
+    assertTrue(cancellation.isActive());
+    StockEventLineItemDto line = cancellation.getLineItems().get(0);
+    assertEquals(original.getId(), line.getReversesEventLineItemId());
+    assertEquals(reason.getId(), line.getReasonId());
+    assertEquals(original.getOrderableId(), line.getOrderableId());
+    assertEquals(original.getQuantity(), line.getQuantity());
+    assertEquals(LocalDate.now(), line.getOccurredDate());
+    assertNull(line.getSourceId());
+    assertNull(line.getDestinationId());
+  }
+
+  @Test(expected = ResourceNotFoundException.class)
+  public void shouldThrowWhenEventDoesNotExist() {
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.empty());
+
+    service.cancel(eventId, requestFor(UUID.randomUUID(), UUID.randomUUID()));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowWhenReasonIsNotCancelTagged() {
+    StockEvent event = eventWithIssueLine();
+    StockEventLineItem original = event.getLineItems().get(0);
+    StockCardLineItemReason reason = reason(ReasonType.CREDIT);
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
+    when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
+
+    service.cancel(eventId, requestFor(original.getId(), reason.getId()));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowWhenReasonTypeDoesNotCounterMovement() {
+    StockEvent event = eventWithIssueLine();
+    StockEventLineItem original = event.getLineItems().get(0);
+    StockCardLineItemReason reason = reason(ReasonType.DEBIT, CANCEL_TAG);
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
+    when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
+
+    service.cancel(eventId, requestFor(original.getId(), reason.getId()));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowWhenReasonIsMissing() {
+    StockEvent event = eventWithIssueLine();
+    StockEventLineItem original = event.getLineItems().get(0);
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
+
+    service.cancel(eventId, requestFor(original.getId(), null));
+  }
+
+  private StockEvent eventWithIssueLine() {
+    StockEventLineItem lineItem = StockEventLineItem.builder()
+        .orderableId(UUID.randomUUID())
+        .lotId(UUID.randomUUID())
+        .quantity(10)
+        .destinationId(UUID.randomUUID())
+        .occurredDate(LocalDate.now())
+        .build();
+    lineItem.setId(UUID.randomUUID());
+    StockEvent event = new StockEvent();
+    event.setId(eventId);
+    event.setFacilityId(facilityId);
+    event.setProgramId(programId);
+    event.setLineItems(singletonList(lineItem));
+    return event;
+  }
+
+  private StockCardLineItemReason reason(ReasonType type, String... tags) {
+    StockCardLineItemReason reason = StockCardLineItemReason.builder()
+        .name("Cancellation " + type)
+        .reasonType(type)
+        .reasonCategory(ReasonCategory.ADJUSTMENT)
+        .tags(asList(tags))
+        .build();
+    reason.setId(UUID.randomUUID());
+    return reason;
+  }
+
+  private StockEventCancelDto requestFor(UUID lineItemId, UUID reasonId) {
+    StockEventCancelLineItemDto lineItem =
+        new StockEventCancelLineItemDto(lineItemId, reasonId, null);
+    return new StockEventCancelDto("signature", singletonList(lineItem));
+  }
+}

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
@@ -17,17 +17,18 @@ package org.openlmis.stockmanagement.service;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_NO_FOLLOWING_PERMISSION;
-import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_TAG;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -50,7 +51,6 @@ import org.openlmis.stockmanagement.dto.StockEventLineItemDto;
 import org.openlmis.stockmanagement.exception.PermissionMessageException;
 import org.openlmis.stockmanagement.exception.ResourceNotFoundException;
 import org.openlmis.stockmanagement.exception.ValidationMessageException;
-import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
 import org.openlmis.stockmanagement.repository.StockEventsRepository;
 import org.openlmis.stockmanagement.util.Message;
 
@@ -64,7 +64,7 @@ public class StockEventCancelServiceTest {
   private StockEventCancelValidationService cancelValidationService;
 
   @Mock
-  private StockCardLineItemReasonRepository reasonRepository;
+  private CancellationReasonResolver reasonResolver;
 
   @Mock
   private StockEventProcessor stockEventProcessor;
@@ -83,12 +83,13 @@ public class StockEventCancelServiceTest {
   public void shouldBuildAndProcessCancellationEvent() {
     StockEvent event = eventWithIssueLine();
     StockEventLineItem original = event.getLineItems().get(0);
-    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_TAG);
+    StockCardLineItemReason reason = reason(ReasonType.CREDIT);
     StockEventCancelDto request = requestFor(original.getId(), reason.getId());
     UUID newEventId = UUID.randomUUID();
     ArgumentCaptor<StockEventDto> captor = ArgumentCaptor.forClass(StockEventDto.class);
     when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
-    when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
+    when(reasonResolver.resolve(anyCollection(), anyMap()))
+        .thenReturn(singletonMap(original.getId(), reason));
     when(stockEventProcessor.process(captor.capture())).thenReturn(newEventId);
 
     UUID result = service.cancel(eventId, request);
@@ -118,34 +119,17 @@ public class StockEventCancelServiceTest {
   }
 
   @Test(expected = ValidationMessageException.class)
-  public void shouldThrowWhenReasonIsNotCancelTagged() {
+  public void shouldThrowWhenLineItemSelectedMoreThanOnce() {
     StockEvent event = eventWithIssueLine();
-    StockEventLineItem original = event.getLineItems().get(0);
-    StockCardLineItemReason reason = reason(ReasonType.CREDIT);
-    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
-    when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
-
-    service.cancel(eventId, requestFor(original.getId(), reason.getId()));
-  }
-
-  @Test(expected = ValidationMessageException.class)
-  public void shouldThrowWhenReasonTypeDoesNotCounterMovement() {
-    StockEvent event = eventWithIssueLine();
-    StockEventLineItem original = event.getLineItems().get(0);
-    StockCardLineItemReason reason = reason(ReasonType.DEBIT, CANCEL_TAG);
-    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
-    when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
-
-    service.cancel(eventId, requestFor(original.getId(), reason.getId()));
-  }
-
-  @Test(expected = ValidationMessageException.class)
-  public void shouldThrowWhenReasonIsMissing() {
-    StockEvent event = eventWithIssueLine();
-    StockEventLineItem original = event.getLineItems().get(0);
+    UUID lineId = event.getLineItems().get(0).getId();
     when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
 
-    service.cancel(eventId, requestFor(original.getId(), null));
+    StockEventCancelLineItemDto first =
+        new StockEventCancelLineItemDto(lineId, UUID.randomUUID(), null);
+    StockEventCancelLineItemDto duplicate =
+        new StockEventCancelLineItemDto(lineId, UUID.randomUUID(), null);
+
+    service.cancel(eventId, new StockEventCancelDto("signature", asList(first, duplicate)));
   }
 
   @Test(expected = PermissionMessageException.class)
@@ -176,12 +160,11 @@ public class StockEventCancelServiceTest {
     return event;
   }
 
-  private StockCardLineItemReason reason(ReasonType type, String... tags) {
+  private StockCardLineItemReason reason(ReasonType type) {
     StockCardLineItemReason reason = StockCardLineItemReason.builder()
         .name("Cancellation " + type)
         .reasonType(type)
         .reasonCategory(ReasonCategory.ADJUSTMENT)
-        .tags(asList(tags))
         .build();
     reason.setId(UUID.randomUUID());
     return reason;

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
@@ -132,6 +132,15 @@ public class StockEventCancelServiceTest {
     service.cancel(eventId, new StockEventCancelDto("signature", asList(first, duplicate)));
   }
 
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowWhenLineItemHasNoStableId() {
+    StockEvent event = eventWithIssueLine();
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
+
+    // A movement recorded before the reversal feature exposes a null stockEventLineItemId.
+    service.cancel(eventId, requestFor(null, UUID.randomUUID()));
+  }
+
   @Test(expected = PermissionMessageException.class)
   public void shouldThrowWhenUserHasNoCancelPermission() {
     StockEvent event = eventWithIssueLine();

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
@@ -23,8 +23,10 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_NO_FOLLOWING_PERMISSION;
 import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_TAG;
 
 import java.time.LocalDate;
@@ -45,10 +47,12 @@ import org.openlmis.stockmanagement.dto.StockEventCancelDto;
 import org.openlmis.stockmanagement.dto.StockEventCancelLineItemDto;
 import org.openlmis.stockmanagement.dto.StockEventDto;
 import org.openlmis.stockmanagement.dto.StockEventLineItemDto;
+import org.openlmis.stockmanagement.exception.PermissionMessageException;
 import org.openlmis.stockmanagement.exception.ResourceNotFoundException;
 import org.openlmis.stockmanagement.exception.ValidationMessageException;
 import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
 import org.openlmis.stockmanagement.repository.StockEventsRepository;
+import org.openlmis.stockmanagement.util.Message;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StockEventCancelServiceTest {
@@ -64,6 +68,9 @@ public class StockEventCancelServiceTest {
 
   @Mock
   private StockEventProcessor stockEventProcessor;
+
+  @Mock
+  private PermissionService permissionService;
 
   @InjectMocks
   private StockEventCancelService service;
@@ -139,6 +146,17 @@ public class StockEventCancelServiceTest {
     when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
 
     service.cancel(eventId, requestFor(original.getId(), null));
+  }
+
+  @Test(expected = PermissionMessageException.class)
+  public void shouldThrowWhenUserHasNoCancelPermission() {
+    StockEvent event = eventWithIssueLine();
+    StockEventLineItem original = event.getLineItems().get(0);
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
+    doThrow(new PermissionMessageException(new Message(ERROR_NO_FOLLOWING_PERMISSION)))
+        .when(permissionService).canCancelStockEvent(any(), any());
+
+    service.cancel(eventId, requestFor(original.getId(), UUID.randomUUID()));
   }
 
   private StockEvent eventWithIssueLine() {

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelValidationServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelValidationServiceTest.java
@@ -1,0 +1,242 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.service;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.when;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_ALREADY_CANCELLED;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_BLOCKED_PHYSICAL_INVENTORY;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_IS_CANCELLATION;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE;
+import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_TAG;
+import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.PHYSICAL_INVENTORY_TYPE;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openlmis.stockmanagement.domain.event.StockEvent;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.openlmis.stockmanagement.domain.physicalinventory.PhysicalInventory;
+import org.openlmis.stockmanagement.domain.reason.ReasonCategory;
+import org.openlmis.stockmanagement.domain.reason.ReasonType;
+import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
+import org.openlmis.stockmanagement.dto.StockEventCancellationLineErrorDto;
+import org.openlmis.stockmanagement.exception.StockEventCancellationException;
+import org.openlmis.stockmanagement.exception.ValidationMessageException;
+import org.openlmis.stockmanagement.repository.PhysicalInventoriesRepository;
+import org.openlmis.stockmanagement.repository.StockCardLineItemReasonRepository;
+import org.openlmis.stockmanagement.repository.StockEventLineItemRepository;
+
+@SuppressWarnings("PMD.TooManyMethods")
+@RunWith(MockitoJUnitRunner.class)
+public class StockEventCancelValidationServiceTest {
+
+  @Mock
+  private StockEventLineItemRepository stockEventLineItemRepository;
+
+  @Mock
+  private PhysicalInventoriesRepository physicalInventoriesRepository;
+
+  @Mock
+  private StockCardLineItemReasonRepository reasonRepository;
+
+  @InjectMocks
+  private StockEventCancelValidationService service;
+
+  private final UUID programId = UUID.randomUUID();
+  private final UUID facilityId = UUID.randomUUID();
+
+  @Test
+  public void shouldNotThrowWhenAllLineItemsCancellable() {
+    StockEventLineItem lineItem = issueLineItem(UUID.randomUUID());
+    StockEvent event = eventWith(lineItem);
+    when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
+        .thenReturn(emptyList());
+    when(physicalInventoriesRepository.findSubmittedAfter(any(), any(), any(), any(), any()))
+        .thenReturn(emptyList());
+
+    service.validate(event, singletonList(lineItem.getId()));
+  }
+
+  @Test
+  public void shouldReportNotCancellableWhenLineItemIsNotIssueOrReceive() {
+    StockEventLineItem lineItem = adjustmentLineItem(UUID.randomUUID());
+    StockEvent event = eventWith(lineItem);
+    when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
+        .thenReturn(emptyList());
+
+    StockEventCancellationLineErrorDto error =
+        assertSingleLineError(event, lineItem.getId());
+
+    assertEquals(ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE, error.getMessageKey());
+    assertNull(error.getBlockingTransactions());
+  }
+
+  @Test
+  public void shouldReportAlreadyCancelledWhenLineItemWasReversed() {
+    StockEventLineItem lineItem = issueLineItem(UUID.randomUUID());
+    StockEvent event = eventWith(lineItem);
+    StockEventLineItem cancellation = StockEventLineItem.builder()
+        .reversesEventLineItemId(lineItem.getId())
+        .build();
+    when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
+        .thenReturn(singletonList(cancellation));
+
+    StockEventCancellationLineErrorDto error =
+        assertSingleLineError(event, lineItem.getId());
+
+    assertEquals(ERROR_EVENT_LINE_ITEM_ALREADY_CANCELLED, error.getMessageKey());
+  }
+
+  @Test
+  public void shouldReportBlockedWhenNewerPhysicalInventoryExists() {
+    final StockEventLineItem lineItem = issueLineItem(UUID.randomUUID());
+    final StockEvent event = eventWith(lineItem);
+    PhysicalInventory inventory = new PhysicalInventory();
+    inventory.setOccurredDate(LocalDate.now());
+    inventory.setDocumentNumber("PI-1");
+    when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
+        .thenReturn(emptyList());
+    when(physicalInventoriesRepository.findSubmittedAfter(any(), any(), any(), any(), any()))
+        .thenReturn(singletonList(inventory));
+
+    StockEventCancellationLineErrorDto error =
+        assertSingleLineError(event, lineItem.getId());
+
+    assertEquals(ERROR_EVENT_LINE_ITEM_BLOCKED_PHYSICAL_INVENTORY, error.getMessageKey());
+    assertEquals(1, error.getBlockingTransactions().size());
+    assertEquals(PHYSICAL_INVENTORY_TYPE, error.getBlockingTransactions().get(0).getType());
+    assertEquals("PI-1", error.getBlockingTransactions().get(0).getDocumentNumber());
+  }
+
+  @Test
+  public void shouldReportIsCancellationWhenOriginalReasonIsCancelTagged() {
+    UUID reasonId = UUID.randomUUID();
+    StockEventLineItem lineItem = issueLineItem(UUID.randomUUID());
+    lineItem.setReasonId(reasonId);
+    StockEvent event = eventWith(lineItem);
+    when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
+        .thenReturn(emptyList());
+    when(reasonRepository.findByIdIn(anyCollection()))
+        .thenReturn(singletonList(cancelReason(reasonId)));
+
+    StockEventCancellationLineErrorDto error =
+        assertSingleLineError(event, lineItem.getId());
+
+    assertEquals(ERROR_EVENT_LINE_ITEM_IS_CANCELLATION, error.getMessageKey());
+  }
+
+  @Test
+  public void shouldCollectErrorsForEveryFailingLineItem() {
+    final StockEventLineItem alreadyCancelled = issueLineItem(UUID.randomUUID());
+    final StockEventLineItem blocked = issueLineItem(UUID.randomUUID());
+    final StockEvent event = eventWith(alreadyCancelled, blocked);
+    StockEventLineItem cancellation = StockEventLineItem.builder()
+        .reversesEventLineItemId(alreadyCancelled.getId())
+        .build();
+    PhysicalInventory inventory = new PhysicalInventory();
+    inventory.setOccurredDate(LocalDate.now());
+    when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
+        .thenReturn(singletonList(cancellation));
+    when(physicalInventoriesRepository.findSubmittedAfter(any(), any(), any(), any(), any()))
+        .thenReturn(singletonList(inventory));
+
+    try {
+      service.validate(event, asList(alreadyCancelled.getId(), blocked.getId()));
+      fail("expected StockEventCancellationException");
+    } catch (StockEventCancellationException ex) {
+      assertEquals(2, ex.getLineErrors().size());
+    }
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowWhenLineItemDoesNotBelongToEvent() {
+    StockEvent event = eventWith(issueLineItem(UUID.randomUUID()));
+
+    service.validate(event, singletonList(UUID.randomUUID()));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowWhenNoLineItemsSelected() {
+    StockEvent event = eventWith(issueLineItem(UUID.randomUUID()));
+
+    service.validate(event, emptyList());
+  }
+
+  private StockEventCancellationLineErrorDto assertSingleLineError(StockEvent event, UUID lineId) {
+    try {
+      service.validate(event, singletonList(lineId));
+      throw new AssertionError("expected StockEventCancellationException");
+    } catch (StockEventCancellationException ex) {
+      List<StockEventCancellationLineErrorDto> errors = ex.getLineErrors();
+      assertEquals(1, errors.size());
+      assertEquals(lineId, errors.get(0).getStockEventLineItemId());
+      return errors.get(0);
+    }
+  }
+
+  private StockEvent eventWith(StockEventLineItem... lineItems) {
+    StockEvent event = new StockEvent();
+    event.setId(UUID.randomUUID());
+    event.setProgramId(programId);
+    event.setFacilityId(facilityId);
+    event.setLineItems(asList(lineItems));
+    return event;
+  }
+
+  private StockEventLineItem issueLineItem(UUID id) {
+    StockEventLineItem lineItem = StockEventLineItem.builder()
+        .orderableId(UUID.randomUUID())
+        .lotId(UUID.randomUUID())
+        .destinationId(UUID.randomUUID())
+        .occurredDate(LocalDate.now())
+        .build();
+    lineItem.setId(id);
+    return lineItem;
+  }
+
+  private StockEventLineItem adjustmentLineItem(UUID id) {
+    StockEventLineItem lineItem = StockEventLineItem.builder()
+        .orderableId(UUID.randomUUID())
+        .occurredDate(LocalDate.now())
+        .build();
+    lineItem.setId(id);
+    return lineItem;
+  }
+
+  private StockCardLineItemReason cancelReason(UUID id) {
+    StockCardLineItemReason reason = StockCardLineItemReason.builder()
+        .name("Cancelled issue")
+        .reasonType(ReasonType.CREDIT)
+        .reasonCategory(ReasonCategory.ADJUSTMENT)
+        .tags(singletonList(CANCEL_TAG))
+        .build();
+    reason.setId(id);
+    return reason;
+  }
+}

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelValidationServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelValidationServiceTest.java
@@ -77,7 +77,8 @@ public class StockEventCancelValidationServiceTest {
     StockEvent event = eventWith(lineItem);
     when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
         .thenReturn(emptyList());
-    when(physicalInventoriesRepository.findSubmittedAfter(any(), any(), any(), any(), any()))
+    when(physicalInventoriesRepository.findSubmittedAfterForOrderableAndLot(
+        any(), any(), any(), any(), any()))
         .thenReturn(emptyList());
 
     service.validate(event, singletonList(lineItem.getId()));
@@ -122,7 +123,8 @@ public class StockEventCancelValidationServiceTest {
     inventory.setDocumentNumber("PI-1");
     when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
         .thenReturn(emptyList());
-    when(physicalInventoriesRepository.findSubmittedAfter(any(), any(), any(), any(), any()))
+    when(physicalInventoriesRepository.findSubmittedAfterForOrderableAndLot(
+        any(), any(), any(), any(), any()))
         .thenReturn(singletonList(inventory));
 
     StockEventCancellationLineErrorDto error =
@@ -132,6 +134,29 @@ public class StockEventCancelValidationServiceTest {
     assertEquals(1, error.getBlockingTransactions().size());
     assertEquals(PHYSICAL_INVENTORY_TYPE, error.getBlockingTransactions().get(0).getType());
     assertEquals("PI-1", error.getBlockingTransactions().get(0).getDocumentNumber());
+  }
+
+  @Test
+  public void shouldUseNoLotQueryWhenLineItemHasNoLot() {
+    final StockEventLineItem lineItem = StockEventLineItem.builder()
+        .orderableId(UUID.randomUUID())
+        .destinationId(UUID.randomUUID())
+        .occurredDate(LocalDate.now())
+        .build();
+    lineItem.setId(UUID.randomUUID());
+    final StockEvent event = eventWith(lineItem);
+    PhysicalInventory inventory = new PhysicalInventory();
+    inventory.setOccurredDate(LocalDate.now());
+    when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
+        .thenReturn(emptyList());
+    when(physicalInventoriesRepository.findSubmittedAfterForOrderableWithoutLot(
+        any(), any(), any(), any()))
+        .thenReturn(singletonList(inventory));
+
+    StockEventCancellationLineErrorDto error =
+        assertSingleLineError(event, lineItem.getId());
+
+    assertEquals(ERROR_EVENT_LINE_ITEM_BLOCKED_PHYSICAL_INVENTORY, error.getMessageKey());
   }
 
   @Test
@@ -163,7 +188,8 @@ public class StockEventCancelValidationServiceTest {
     inventory.setOccurredDate(LocalDate.now());
     when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
         .thenReturn(singletonList(cancellation));
-    when(physicalInventoriesRepository.findSubmittedAfter(any(), any(), any(), any(), any()))
+    when(physicalInventoriesRepository.findSubmittedAfterForOrderableAndLot(
+        any(), any(), any(), any(), any()))
         .thenReturn(singletonList(inventory));
 
     try {

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelValidationServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelValidationServiceTest.java
@@ -78,7 +78,7 @@ public class StockEventCancelValidationServiceTest {
     when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
         .thenReturn(emptyList());
     when(physicalInventoriesRepository.findSubmittedAfterForOrderableAndLot(
-        any(), any(), any(), any(), any()))
+        any(), any(), any(), any(), any(), any()))
         .thenReturn(emptyList());
 
     service.validate(event, singletonList(lineItem.getId()));
@@ -124,7 +124,7 @@ public class StockEventCancelValidationServiceTest {
     when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
         .thenReturn(emptyList());
     when(physicalInventoriesRepository.findSubmittedAfterForOrderableAndLot(
-        any(), any(), any(), any(), any()))
+        any(), any(), any(), any(), any(), any()))
         .thenReturn(singletonList(inventory));
 
     StockEventCancellationLineErrorDto error =
@@ -150,7 +150,7 @@ public class StockEventCancelValidationServiceTest {
     when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
         .thenReturn(emptyList());
     when(physicalInventoriesRepository.findSubmittedAfterForOrderableWithoutLot(
-        any(), any(), any(), any()))
+        any(), any(), any(), any(), any()))
         .thenReturn(singletonList(inventory));
 
     StockEventCancellationLineErrorDto error =
@@ -189,7 +189,7 @@ public class StockEventCancelValidationServiceTest {
     when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(anyCollection()))
         .thenReturn(singletonList(cancellation));
     when(physicalInventoriesRepository.findSubmittedAfterForOrderableAndLot(
-        any(), any(), any(), any(), any()))
+        any(), any(), any(), any(), any(), any()))
         .thenReturn(singletonList(inventory));
 
     try {

--- a/src/test/java/org/openlmis/stockmanagement/testutils/StockCardLineItemDataBuilder.java
+++ b/src/test/java/org/openlmis/stockmanagement/testutils/StockCardLineItemDataBuilder.java
@@ -166,7 +166,7 @@ public class StockCardLineItemDataBuilder {
     StockCardLineItem lineItem = new StockCardLineItem(
         stockCard, originEvent, quantity, extraData, reason, sourceFreeText, destinationFreeText,
         documentNumber, reasonFreeText, signature, source, destination, occurredDate,
-        processedDateTime, userId, stockOnHand, username, stockAdjustments
+        processedDateTime, userId, null, stockOnHand, username, stockAdjustments
     );
     lineItem.setId(id);
 

--- a/src/test/java/org/openlmis/stockmanagement/testutils/StockEventLineItemDtoDataBuilder.java
+++ b/src/test/java/org/openlmis/stockmanagement/testutils/StockEventLineItemDtoDataBuilder.java
@@ -57,8 +57,8 @@ public class StockEventLineItemDtoDataBuilder {
    */
   public StockEventLineItemDto buildForAdjustment() {
     noSourceAndDestination();
-    return new StockEventLineItemDto(orderableId, lotId,quantity, extraData, occurredDate, reasonId,
-        reasonFreeText, sourceId, sourceFreeText, destinationId, destinationFreeText,
+    return new StockEventLineItemDto(null, orderableId, lotId, quantity, extraData, occurredDate,
+        reasonId, reasonFreeText, sourceId, sourceFreeText, destinationId, destinationFreeText,
         reversesEventLineItemId, stockAdjustments);
   }
 
@@ -66,8 +66,8 @@ public class StockEventLineItemDtoDataBuilder {
    * Build new Stock Event.
    */
   public StockEventLineItemDto build() {
-    return new StockEventLineItemDto(orderableId, lotId,quantity, extraData, occurredDate, reasonId,
-        reasonFreeText, sourceId, sourceFreeText, destinationId, destinationFreeText,
+    return new StockEventLineItemDto(null, orderableId, lotId, quantity, extraData, occurredDate,
+        reasonId, reasonFreeText, sourceId, sourceFreeText, destinationId, destinationFreeText,
         reversesEventLineItemId, stockAdjustments);
   }
 

--- a/src/test/java/org/openlmis/stockmanagement/testutils/StockEventLineItemDtoDataBuilder.java
+++ b/src/test/java/org/openlmis/stockmanagement/testutils/StockEventLineItemDtoDataBuilder.java
@@ -39,6 +39,7 @@ public class StockEventLineItemDtoDataBuilder {
   private String sourceFreeText = RandomStringUtils.random(5);
   private UUID destinationId = UUID.randomUUID();
   private String destinationFreeText = RandomStringUtils.random(5);
+  private UUID reversesEventLineItemId = null;
   private List<StockEventAdjustmentDto> stockAdjustments = new ArrayList<>();
 
   /**
@@ -58,7 +59,7 @@ public class StockEventLineItemDtoDataBuilder {
     noSourceAndDestination();
     return new StockEventLineItemDto(orderableId, lotId,quantity, extraData, occurredDate, reasonId,
         reasonFreeText, sourceId, sourceFreeText, destinationId, destinationFreeText,
-        stockAdjustments);
+        reversesEventLineItemId, stockAdjustments);
   }
 
   /**
@@ -67,7 +68,7 @@ public class StockEventLineItemDtoDataBuilder {
   public StockEventLineItemDto build() {
     return new StockEventLineItemDto(orderableId, lotId,quantity, extraData, occurredDate, reasonId,
         reasonFreeText, sourceId, sourceFreeText, destinationId, destinationFreeText,
-        stockAdjustments);
+        reversesEventLineItemId, stockAdjustments);
   }
 
   /**
@@ -98,6 +99,12 @@ public class StockEventLineItemDtoDataBuilder {
 
   public StockEventLineItemDtoDataBuilder withOrderableId(UUID orderableId) {
     this.orderableId = orderableId;
+    return this;
+  }
+
+  public StockEventLineItemDtoDataBuilder withReversesEventLineItemId(
+      UUID reversesEventLineItemId) {
+    this.reversesEventLineItemId = reversesEventLineItemId;
     return this;
   }
 


### PR DESCRIPTION
## Summary

Backend for cancelling specific **issue** or **receive** stock movements, plus the read-side resolution of the resulting cancellation cross-links (**SELV3-858 + SELV3-861**, part of the *"Cancel Stock Issue or Receive Movement"* HLD).

Cancelling is **not** a physical return: the original event is left untouched for traceability, and a new **ADJUSTMENT** stock event reverses the selected line items — a cancelled issue is reversed with a **credit**, a cancelled receive with a **debit**. Stock on hand is recalculated through the standard `StockEventProcessor` path. Line items are reversed **independently** (partial cancellation) but as a single transaction.

On the read side, the two stock read DTOs surface the link between an original movement and the event that cancelled it (**"Reversing"** / **"Reversed by"**), resolved per read page — the original event is left untouched rather than denormalising a forward reference onto it.

Scope is **backend only**; the UI (reverse view, marking cancelled documents, confirmation summary) is tracked in sibling tickets (SELV3-859 / SELV3-860).

## Jira / HLD

- **SELV3-858** — Cancel endpoint & handling
- **SELV3-861** — Resolve cancellation cross-links on the stock read DTOs *(merged into this branch)*
- HLD: *Cancel Stock Issue or Receive Movement*

## Endpoint

`POST /api/stockEvents/{id}/cancel`

Request body:

```json
{
  "signature": "J. Doe",
  "lineItems": [
    { "stockEventLineItemId": "uuid", "reasonId": "uuid", "reasonFreeText": "optional" }
  ]
}
```

| Status | Body | When |
|---|---|---|
| `201` | `uuid` | Cancellation event created; returns its id |
| `400` | `stockEventCancellationError` | Validation failed. Per-line eligibility failures populate `lineErrors[]`; other failures (invalid request, reason, negative SoH, concurrent modification) return only the general message |
| `403` | `localizedMessage` | Missing `STOCK_EVENTS_CANCEL` for the facility/program |
| `404` | `localizedMessage` | Stock event not found |

## Cancel endpoint & handling (SELV3-858)

**Domain & schema**
- `StockEventLineItem`: new nullable `reversesEventLineItemId` (FK to the reversed line item) + domain predicates `isIssue()` / `isReceive()` / `isMovement()`.
- Migration: `reverseseventlineitemid` column, FK, and a **partial unique index** (an original line can be reversed at most once — also drives already-cancelled detection and concurrent-modification handling).
- Migration: two `cancel`-tagged **ADJUSTMENT** reasons (CREDIT "Cancelled issue", DEBIT "Cancelled receipt"). Intentionally **not** added to `valid_reason_assignments` (cancellation has its own path and is not gated by valid-reason assignment).

**Service layer**
- `StockEventCancelService` — orchestrates: load event → authorize → validate → build reversing adjustment event → delegate to `StockEventProcessor` (persist + recalc SoH).
- `StockEventCancelValidationService` — per-line validation as an ordered rule list (issue/receive type, not already cancelled, not itself a cancellation, no blocking physical inventory); collects **all** failures.
- `CancellationReasonResolver` — loads and validates the chosen reason (cancel-tagged, ADJUSTMENT, type counters the movement).
- `PermissionService.canCancelStockEvent(...)` + `STOCK_EVENTS_CANCEL` right constant.

**Repositories**
- `StockEventLineItemRepository.findByReversesEventLineItemIdIn(...)` — already-cancelled detection.
- `PhysicalInventoriesRepository` — queries for submitted physical inventories recorded after a movement (separate lot / no-lot variants), applied at line-item level.

**Error handling**
- `StockEventCancellationException` + `StockEventCancellationErrorDto` / `StockEventCancellationLineErrorDto` / `BlockingTransactionDto` — per-line feedback marking which lines block cancellation and why.
- `GlobalErrorHandling` — maps the reverses unique-index violation to `ERROR_EVENT_CANCELLATION_CONCURRENT_MODIFICATION` (optimistic-locking-equivalent).
- New message keys in `MessageKeys` / `messages_en.properties`.

**DTOs & API docs**
- Request DTOs (`StockEventCancelDto`, `StockEventCancelLineItemDto`); `StockEventLineItemDto.reversesEventLineItemId` is `READ_ONLY` (server-set only).
- `api-definition.yaml` + JSON schemas for request and error.

## Read-side cancellation cross-links (SELV3-861)

Resolves, per read page, the cross-links between an issue/receive event and the event that cancelled it, on both stock read DTOs (stock card and transaction-history detail):

- **"Reversing"** — on a cancellation line, links to the original event it reverses.
- **"Reversed by"** — on an original line, links to the cancellation event (resolved via `findByReversesEventLineItemIdIn`).

**Stable line identity.** To identify a line reliably — needed for partial cancellation and for keying the links, since the `(event, orderable, lot)` tuple is not unique — each generated stock card line item now records the stock event line item it was created from:
- New nullable column `stock_card_line_items.origineventlineitemid` (migration), set in `StockCardLineItem.createLineItemFrom` from the persisted `StockEventLineItem` id; `StockEventProcessor.copyPersistedLineItemIds` writes the ids back onto the request DTO after save, relying on the 1:1 in-order mapping of `toEvent()`.
- Exposed as `stockEventLineItemId` on `StockCardLineItemDto` and `StockEventLineDetailDto`.
- `CancellationLinkResolver` keys the links on it (the earlier non-unique `(event, orderable, lot)` lookup was removed).

**Resolution is gated** behind `createDtos(cards, withCancellationLinks)` so read paths that immediately discard line items (e.g. stock card summaries, the summaries PDF) don't pay for the extra queries.

**Forward-only linkage.** The column is populated for movements recorded from this version onward. Movements recorded earlier have no stable identifier and therefore cannot be cancelled through the reversal flow:
- an explicit guard rejects such a request with a dedicated message (`ERROR_EVENT_LINE_ITEM_MISSING_ID`) instead of surfacing as a confusing not-found;
- the write-path logs (with the event id and both list sizes) if the linkage ever fails to populate, so an unlinked movement is detectable without failing the stock event;
- the limitation is recorded in the changelog.

## Acceptance criteria

| AC | Covered by |
|---|---|
| AC#1 Stock quantity restriction (SoH ≥ 0) | Standard recalculation (`CalculatedStockOnHandService`) during processing |
| AC#2 Partial cancellation (per-line, transactional) | Per-line selection keyed on the stable `stockEventLineItemId` + `@Transactional` (all-or-nothing) |
| AC#3 Physical inventory block (line-level) | `PhysicalInventoriesRepository` queries → per-line error with `blockingTransactions[]` |
| AC#4 Cancelled documents remain visible | Original event untouched; cross-links resolved on read (`CancellationLinkResolver`) and surfaced as "Reversing" / "Reversed by" |
| AC#5 Stock on hand recalculation | Delegated to `StockEventProcessor` |
| AC#6 Cancellation role & facility scope | `STOCK_EVENTS_CANCEL` (SUPERVISION → home/supervised facility) |
| AC#7 Cancellation reason | Cancel-tagged ADJUSTMENT reasons, recorded per reversed line |
| AC#8 Confirmation summary | UI — out of scope for this ticket |
| AC#9 Line-level error feedback | `StockEventCancellationErrorDto.lineErrors[]` |

## Dependencies

Requires the companion **referencedata** change that introduces the `STOCK_EVENTS_CANCEL` supervision right (and grants it to the demo Stock Manager role). Must be merged/deployed together.

## Testing

- **Unit (SELV3-858):** `StockEventCancelServiceTest`, `StockEventCancelValidationServiceTest`, `CancellationReasonResolverTest`, `StockEventLineItemTest`, plus additions to `GlobalErrorHandlingTest`, `PermissionServiceTest`, `StockEventLineItemDtoTest`.
- **Unit (SELV3-861):** `CancellationLinkResolverTest` (link resolution + reversed-by attachment), `StockCardLineItemDtoTest` / `StockEventLineDetailDtoTest` (`stockEventLineItemId` exposure), and `StockEventCancelServiceTest.shouldThrowWhenLineItemHasNoStableId` (the missing-id guard).
- **Integration:** `StockEventCancelIntegrationTest` (endpoint status mapping), `PhysicalInventoriesRepositoryIntegrationTest` (PI-block queries).
- `gradle clean build` green (checkstyle, PMD, unit, integration, RAML).

## Out of scope / follow-ups

- UI (reverse view, cancelled-document markers, confirmation summary) — SELV3-859 / SELV3-860.
- Backfill of `origineventlineitemid` for pre-existing rows: intentionally not done (movements recorded before this version are not cancellable); can be added as a separate, deliberately-scoped migration if reversing historical movements is required later.
- Repo-wide migration of the deprecated `org.mockito.runners.MockitoJUnitRunner` (pre-existing, 46 files).