### PR TITLE
SELV3-861: Resolve cancellation cross-links on stock read DTOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Upcoming Version (WIP)
 ==================
+* [SELV3-861](https://openlmis.atlassian.net/browse/SELV3-861): Resolve the "Reversing"/"Reversed by" cancellation cross-links on stock read DTOs and expose a stable `stockEventLineItemId` on the stock card and transaction-history line items, backed by a new `origineventlineitemid` column recording the stock event line item each stock card line item was created from. The column is populated for movements recorded from this version onward; movements recorded earlier have no stable line identifier and therefore cannot be cancelled through the reversal flow.
 * [SELV3-858](https://openlmis.atlassian.net/browse/SELV3-858): Added `POST /api/stockEvents/{id}/cancel` endpoint to cancel selected issue/receive line items. Introduces the `STOCK_EVENTS_CANCEL` right, a `reverseseventlineitemid` column on stock event line items, and cancel-tagged adjustment reasons. Cancellation creates a reversing adjustment stock event and recalculates stock on hand; the original event is preserved.
 * [OLMIS-8198](https://openlmis.atlassian.net/browse/OLMIS-8198): Add packs support to stock card and stock card summary reports.
 * [SELV3-849](https://openlmis.atlassian.net/browse/SELV3-849) Unified StockCardLineItem ordering on retrieval

--- a/src/integration-test/java/org/openlmis/stockmanagement/service/StockEventProcessorIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/service/StockEventProcessorIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.openlmis.stockmanagement.service;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
@@ -33,6 +34,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.openlmis.stockmanagement.BaseIntegrationTest;
+import org.openlmis.stockmanagement.domain.card.StockCardLineItem;
 import org.openlmis.stockmanagement.domain.reason.ReasonCategory;
 import org.openlmis.stockmanagement.domain.reason.ReasonType;
 import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
@@ -191,6 +193,35 @@ public class StockEventProcessorIntegrationTest extends BaseIntegrationTest {
     //then
     assertSize(cardSize + 1, eventSize + 1, lineItemSize + 1);
     verify(stockEventNotificationProcessor).callAllNotifications(stockEventDto);
+  }
+
+  @Test
+  public void shouldRecordOriginEventLineItemIdOnGeneratedStockCardLineItem() {
+    StockEventDto stockEventDto = createStockEventDto();
+    stockEventDto.getLineItems().get(0).setReasonId(reason.getId());
+    stockEventDto.getLineItems().get(0).setSourceId(node.getId());
+    stockEventDto.getLineItems().get(0).setDestinationId(node.getId());
+    stockEventDto.setUserId(userId);
+    stockEventDto.setActive(true);
+    setContext(stockEventDto);
+
+    UUID savedEventId = stockEventProcessor.process(stockEventDto);
+
+    // the generated stock card line item records the persisted stock event line item it came from
+    UUID eventLineItemId = stockEventsRepository.findById(savedEventId)
+        .orElseThrow(AssertionError::new)
+        .getLineItems().get(0).getId();
+
+    StockCardLineItem generated = null;
+    for (StockCardLineItem item : lineItemRepository.findAll()) {
+      if (item.getOriginEvent() != null && savedEventId.equals(item.getOriginEvent().getId())) {
+        generated = item;
+        break;
+      }
+    }
+
+    assertThat(generated, is(notNullValue()));
+    assertThat(generated.getOriginEventLineItemId(), is(eventLineItemId));
   }
 
   @Test

--- a/src/main/java/org/openlmis/stockmanagement/domain/card/StockCardLineItem.java
+++ b/src/main/java/org/openlmis/stockmanagement/domain/card/StockCardLineItem.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
     "stockCard", "originEvent",
     "source", "destination",
     "processedDate",
-    "userId"})
+    "userId", "originEventLineItemId"})
 @Table(name = "stock_card_line_items", schema = "stockmanagement")
 public class StockCardLineItem extends BaseEntity {
 
@@ -111,6 +111,11 @@ public class StockCardLineItem extends BaseEntity {
 
   @Column
   private UUID userId;
+
+  // The stock event line item this row was created from: lets reads expose a stable
+  // stockEventLineItemId to identify the exact line for cancellation and its cross-links.
+  @Column
+  private UUID originEventLineItemId;
 
   @Transient
   private Integer stockOnHand;
@@ -178,6 +183,7 @@ public class StockCardLineItem extends BaseEntity {
         .userId(eventDto.getContext().getCurrentUserId())
 
         .extraData(eventLineItem.getExtraData())
+        .originEventLineItemId(eventLineItem.getId())
         .build();
 
     stockCard.getLineItems().add(cardLineItem);

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockCardLineItemDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockCardLineItemDto.java
@@ -37,13 +37,17 @@ public class StockCardLineItemDto {
   private UUID originEventId;
   private EventOrigin eventOrigin;
 
-  // Set on read for a cancellation line: the original event it reverses (SELV3-860 "Reversing").
+  // Set on read for a cancellation line: the original event it reverses (the "Reversing" column).
   private UUID reversedEventId;
   private String reversedEventDocumentNumber;
 
-  // Set on read for an original line: the cancellation event that reversed it (SELV3-860).
+  // Set on read for an original line: the cancellation event that reversed it ("Reversed by").
   private UUID cancellationEventId;
   private String cancellationEventDocumentNumber;
+
+  // The stock event line item this row was created from: a stable, unique id the
+  // reverse view uses to cancel the exact line, and the resolver uses as the cross-link key.
+  private UUID stockEventLineItemId;
 
   /**
    * Create stock card line item dto from stock card line item.
@@ -57,6 +61,7 @@ public class StockCardLineItemDto {
         .lineItem(stockCardLineItem)
         .originEventId(originEvent == null ? null : originEvent.getId())
         .eventOrigin(originEvent == null ? null : originEvent.getEventOrigin())
+        .stockEventLineItemId(stockCardLineItem.getOriginEventLineItemId())
         .build();
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockCardLineItemDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockCardLineItemDto.java
@@ -37,6 +37,14 @@ public class StockCardLineItemDto {
   private UUID originEventId;
   private EventOrigin eventOrigin;
 
+  // Set on read for a cancellation line: the original event it reverses (SELV3-860 "Reversing").
+  private UUID reversedEventId;
+  private String reversedEventDocumentNumber;
+
+  // Set on read for an original line: the cancellation event that reversed it (SELV3-860).
+  private UUID cancellationEventId;
+  private String cancellationEventDocumentNumber;
+
   /**
    * Create stock card line item dto from stock card line item.
    *

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineDetailDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineDetailDto.java
@@ -43,13 +43,17 @@ public class StockEventLineDetailDto {
   private Integer stockOnHand;
   private String documentNumber;
 
-  // For a cancellation row: the original event it reverses (SELV3-860 "Reversing"). Null otherwise.
+  // For a cancellation row: the original event it reverses ("Reversing" column). Null otherwise.
   private UUID reversedEventId;
   private String reversedEventDocumentNumber;
 
-  // For an original row: the cancellation event that reversed it (SELV3-860). Null otherwise.
+  // For an original row: the cancellation event that reversed it ("Reversed by"). Null otherwise.
   private UUID cancellationEventId;
   private String cancellationEventDocumentNumber;
+
+  // The stock event line item this row corresponds to. The reverse view sends it to
+  // select the exact line to cancel, and per-line cancellation errors (AC#9) join on it.
+  private UUID stockEventLineItemId;
 
   /**
    * Flattens one resolved stock card line item (with its parent card's product/lot) into a single
@@ -76,6 +80,7 @@ public class StockEventLineDetailDto {
         .reversedEventDocumentNumber(lineItem.getReversedEventDocumentNumber())
         .cancellationEventId(lineItem.getCancellationEventId())
         .cancellationEventDocumentNumber(lineItem.getCancellationEventDocumentNumber())
+        .stockEventLineItemId(lineItem.getStockEventLineItemId())
         .build();
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineDetailDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineDetailDto.java
@@ -16,6 +16,7 @@
 package org.openlmis.stockmanagement.dto;
 
 import java.time.LocalDate;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -42,6 +43,14 @@ public class StockEventLineDetailDto {
   private Integer stockOnHand;
   private String documentNumber;
 
+  // For a cancellation row: the original event it reverses (SELV3-860 "Reversing"). Null otherwise.
+  private UUID reversedEventId;
+  private String reversedEventDocumentNumber;
+
+  // For an original row: the cancellation event that reversed it (SELV3-860). Null otherwise.
+  private UUID cancellationEventId;
+  private String cancellationEventDocumentNumber;
+
   /**
    * Flattens one resolved stock card line item (with its parent card's product/lot) into a single
    * transaction-history detail row.
@@ -63,6 +72,10 @@ public class StockEventLineDetailDto {
         .reason(item.getReason())
         .stockOnHand(item.getStockOnHand())
         .documentNumber(item.getDocumentNumber())
+        .reversedEventId(lineItem.getReversedEventId())
+        .reversedEventDocumentNumber(lineItem.getReversedEventDocumentNumber())
+        .cancellationEventId(lineItem.getCancellationEventId())
+        .cancellationEventDocumentNumber(lineItem.getCancellationEventDocumentNumber())
         .build();
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineItemDto.java
+++ b/src/main/java/org/openlmis/stockmanagement/dto/StockEventLineItemDto.java
@@ -41,6 +41,10 @@ import org.openlmis.stockmanagement.domain.physicalinventory.PhysicalInventoryLi
 @NoArgsConstructor
 @Builder
 public class StockEventLineItemDto implements IdentifiableByOrderableLot, VvmApplicable {
+  // Set server-side after the event is persisted (so generated stock card line items can record
+  // their origin); ignored if provided by clients on the create path.
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private UUID id;
   private UUID orderableId;
   private UUID lotId;
   private Integer quantity;

--- a/src/main/java/org/openlmis/stockmanagement/i18n/MessageKeys.java
+++ b/src/main/java/org/openlmis/stockmanagement/i18n/MessageKeys.java
@@ -205,6 +205,8 @@ public abstract class MessageKeys {
       + ".cancellation.concurrentModification";
   public static final String ERROR_EVENT_LINE_ITEM_NOT_FOUND = EVENT_ERROR_PREFIX
       + ".lineItem.notFound";
+  public static final String ERROR_EVENT_LINE_ITEM_MISSING_ID = EVENT_ERROR_PREFIX
+      + ".lineItem.missingId";
   public static final String ERROR_EVENT_LINE_ITEM_DUPLICATE = EVENT_ERROR_PREFIX
       + ".lineItem.duplicate";
   public static final String ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE = EVENT_ERROR_PREFIX

--- a/src/main/java/org/openlmis/stockmanagement/repository/StockEventLineItemRepository.java
+++ b/src/main/java/org/openlmis/stockmanagement/repository/StockEventLineItemRepository.java
@@ -43,15 +43,4 @@ public interface StockEventLineItemRepository
    */
   List<StockEventLineItem> findByStockEventIdInAndReversesEventLineItemIdIsNotNull(
       Collection<UUID> stockEventIds);
-
-  /**
-   * Returns the line items of the given stock events for the given orderables. Used to resolve the
-   * original line item behind each shown line (matched by event + orderable + lot).
-   *
-   * @param stockEventIds ids of the stock events shown on the page.
-   * @param orderableIds  ids of the orderables shown on the page.
-   * @return the matching line items.
-   */
-  List<StockEventLineItem> findByStockEventIdInAndOrderableIdIn(
-      Collection<UUID> stockEventIds, Collection<UUID> orderableIds);
 }

--- a/src/main/java/org/openlmis/stockmanagement/repository/StockEventLineItemRepository.java
+++ b/src/main/java/org/openlmis/stockmanagement/repository/StockEventLineItemRepository.java
@@ -32,4 +32,26 @@ public interface StockEventLineItemRepository
    * @return the cancellation line items pointing at any of the given ids.
    */
   List<StockEventLineItem> findByReversesEventLineItemIdIn(Collection<UUID> reversedLineItemIds);
+
+  /**
+   * Returns the cancellation line items (those that reverse another line) belonging to any of the
+   * given stock events. Used to detect which shown events are cancellations and which original
+   * line they reverse.
+   *
+   * @param stockEventIds ids of the stock events shown on the page.
+   * @return the cancellation line items of those events.
+   */
+  List<StockEventLineItem> findByStockEventIdInAndReversesEventLineItemIdIsNotNull(
+      Collection<UUID> stockEventIds);
+
+  /**
+   * Returns the line items of the given stock events for the given orderables. Used to resolve the
+   * original line item behind each shown line (matched by event + orderable + lot).
+   *
+   * @param stockEventIds ids of the stock events shown on the page.
+   * @param orderableIds  ids of the orderables shown on the page.
+   * @return the matching line items.
+   */
+  List<StockEventLineItem> findByStockEventIdInAndOrderableIdIn(
+      Collection<UUID> stockEventIds, Collection<UUID> orderableIds);
 }

--- a/src/main/java/org/openlmis/stockmanagement/service/CancellationLinkResolver.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/CancellationLinkResolver.java
@@ -1,0 +1,196 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.service;
+
+import static java.util.Collections.emptyMap;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.openlmis.stockmanagement.domain.event.StockEvent;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.openlmis.stockmanagement.dto.StockCardLineItemDto;
+import org.openlmis.stockmanagement.repository.StockEventLineItemRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves, per page and read-side only, the cross-links between an issue/receive event and the
+ * event that cancelled it (SELV3-861, Scenario 2 - the original event is left untouched):
+ * "Reversing" (a cancellation line links to the original event it reverses) and "Reversed by"
+ * (an original line links to the cancellation event that reversed it).
+ */
+@Service
+@RequiredArgsConstructor
+public class CancellationLinkResolver {
+
+  private final StockEventLineItemRepository stockEventLineItemRepository;
+
+  /**
+   * Sets both cancellation cross-links on the given stock card line item DTOs, in batch.
+   *
+   * @param lineItems the stock card line item DTOs shown on the current page.
+   */
+  public void attachCancellationLinks(List<StockCardLineItemDto> lineItems) {
+    if (lineItems == null || lineItems.isEmpty()) {
+      return;
+    }
+    attachReversing(lineItems);
+    attachReversedBy(lineItems);
+  }
+
+  // "Reversing": for a cancellation line, the original event it reverses (once per cancellation
+  // event, since a cancellation reverses exactly one original event).
+  private void attachReversing(List<StockCardLineItemDto> lineItems) {
+    Map<UUID, StockEvent> reversedByCancellationEvent = reversedEvents(lineItems);
+    for (StockCardLineItemDto lineItem : lineItems) {
+      StockEvent originEvent = originEventOf(lineItem);
+      StockEvent reversed = originEvent == null
+          ? null : reversedByCancellationEvent.get(originEvent.getId());
+      if (reversed != null) {
+        lineItem.setReversedEventId(reversed.getId());
+        lineItem.setReversedEventDocumentNumber(reversed.getDocumentNumber());
+      }
+    }
+  }
+
+  // "Reversed by": for an original line, the cancellation event that reversed it. Matched per line
+  // (event + orderable + lot) so a partial cancellation marks only the line that was cancelled.
+  private void attachReversedBy(List<StockCardLineItemDto> lineItems) {
+    Set<UUID> eventIds = new HashSet<>();
+    Set<UUID> orderableIds = new HashSet<>();
+    collectEventAndOrderableIds(lineItems, eventIds, orderableIds);
+    if (eventIds.isEmpty()) {
+      return;
+    }
+    Map<LineKey, UUID> originLineIdByKey = originLineIdsByKey(eventIds, orderableIds);
+    Map<UUID, StockEvent> cancellationByOriginLine =
+        cancellationEventsByOriginLine(originLineIdByKey.values());
+    for (StockCardLineItemDto dto : lineItems) {
+      setReversedBy(dto, originLineIdByKey, cancellationByOriginLine);
+    }
+  }
+
+  private void collectEventAndOrderableIds(List<StockCardLineItemDto> lineItems,
+      Set<UUID> eventIds, Set<UUID> orderableIds) {
+    for (StockCardLineItemDto dto : lineItems) {
+      LineKey key = LineKey.of(dto);
+      if (key != null) {
+        eventIds.add(key.getEventId());
+        orderableIds.add(key.getOrderableId());
+      }
+    }
+  }
+
+  // (event, orderable, lot) -> original line id
+  private Map<LineKey, UUID> originLineIdsByKey(Set<UUID> eventIds, Set<UUID> orderableIds) {
+    Map<LineKey, UUID> map = new HashMap<>();
+    for (StockEventLineItem line : stockEventLineItemRepository
+        .findByStockEventIdInAndOrderableIdIn(eventIds, orderableIds)) {
+      map.putIfAbsent(
+          new LineKey(line.getStockEvent().getId(), line.getOrderableId(), line.getLotId()),
+          line.getId());
+    }
+    return map;
+  }
+
+  // original line id -> the cancellation event that reverses it
+  private Map<UUID, StockEvent> cancellationEventsByOriginLine(Collection<UUID> originLineIds) {
+    Map<UUID, StockEvent> map = new HashMap<>();
+    for (StockEventLineItem cancellationLine :
+        stockEventLineItemRepository.findByReversesEventLineItemIdIn(originLineIds)) {
+      map.putIfAbsent(cancellationLine.getReversesEventLineItemId(),
+          cancellationLine.getStockEvent());
+    }
+    return map;
+  }
+
+  private void setReversedBy(StockCardLineItemDto dto, Map<LineKey, UUID> originLineIdByKey,
+      Map<UUID, StockEvent> cancellationByOriginLine) {
+    LineKey key = LineKey.of(dto);
+    if (key == null) {
+      return;
+    }
+    StockEvent cancellation = cancellationByOriginLine.get(originLineIdByKey.get(key));
+    if (cancellation != null) {
+      dto.setCancellationEventId(cancellation.getId());
+      dto.setCancellationEventDocumentNumber(cancellation.getDocumentNumber());
+    }
+  }
+
+  private Map<UUID, StockEvent> reversedEvents(List<StockCardLineItemDto> lineItems) {
+    Set<UUID> eventIds = new HashSet<>();
+    for (StockCardLineItemDto dto : lineItems) {
+      StockEvent originEvent = originEventOf(dto);
+      if (originEvent != null) {
+        eventIds.add(originEvent.getId());
+      }
+    }
+    if (eventIds.isEmpty()) {
+      return emptyMap();
+    }
+
+    Map<UUID, UUID> reversedLineByEvent = new HashMap<>();
+    for (StockEventLineItem cancellationLine : stockEventLineItemRepository
+        .findByStockEventIdInAndReversesEventLineItemIdIsNotNull(eventIds)) {
+      reversedLineByEvent.putIfAbsent(cancellationLine.getStockEvent().getId(),
+          cancellationLine.getReversesEventLineItemId());
+    }
+
+    Map<UUID, StockEvent> eventByOriginLine = new HashMap<>();
+    stockEventLineItemRepository.findAllById(reversedLineByEvent.values())
+        .forEach(line -> eventByOriginLine.put(line.getId(), line.getStockEvent()));
+
+    Map<UUID, StockEvent> result = new HashMap<>();
+    reversedLineByEvent.forEach((cancellationEventId, originLineId) -> {
+      StockEvent originEvent = eventByOriginLine.get(originLineId);
+      if (originEvent != null) {
+        result.put(cancellationEventId, originEvent);
+      }
+    });
+    return result;
+  }
+
+  private static StockEvent originEventOf(StockCardLineItemDto dto) {
+    return dto.getLineItem() == null ? null : dto.getLineItem().getOriginEvent();
+  }
+
+  // Identifies a shown line by (origin event, orderable, lot): the tuple that matches a stock
+  // card line item to its stock event line item. A value object (not a stringly-typed key) so a
+  // null lot compares as an absent value rather than the literal text "null".
+  @Value
+  private static class LineKey {
+    UUID eventId;
+    UUID orderableId;
+    UUID lotId;
+
+    // The key of a shown line, or null when the origin event / owning card is unavailable.
+    static LineKey of(StockCardLineItemDto dto) {
+      StockEvent originEvent = originEventOf(dto);
+      if (originEvent == null || dto.getLineItem().getStockCard() == null) {
+        return null;
+      }
+      return new LineKey(originEvent.getId(),
+          dto.getLineItem().getStockCard().getOrderableId(),
+          dto.getLineItem().getStockCard().getLotId());
+    }
+  }
+}

--- a/src/main/java/org/openlmis/stockmanagement/service/CancellationLinkResolver.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/CancellationLinkResolver.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import org.openlmis.stockmanagement.domain.event.StockEvent;
 import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
 import org.openlmis.stockmanagement.dto.StockCardLineItemDto;
@@ -34,7 +33,7 @@ import org.springframework.stereotype.Service;
 
 /**
  * Resolves, per page and read-side only, the cross-links between an issue/receive event and the
- * event that cancelled it (SELV3-861, Scenario 2 - the original event is left untouched):
+ * event that cancelled it (resolved on read; the original event is left untouched):
  * "Reversing" (a cancellation line links to the original event it reverses) and "Reversed by"
  * (an original line links to the cancellation event that reversed it).
  */
@@ -72,44 +71,27 @@ public class CancellationLinkResolver {
     }
   }
 
-  // "Reversed by": for an original line, the cancellation event that reversed it. Matched per line
-  // (event + orderable + lot) so a partial cancellation marks only the line that was cancelled.
+  // "Reversed by": for an original line, the cancellation event that reversed it, keyed by the
+  // line's own stock event line item id - stable and unique, unlike an orderable+lot match - so a
+  // partial cancellation marks only the line that was actually cancelled.
   private void attachReversedBy(List<StockCardLineItemDto> lineItems) {
-    Set<UUID> eventIds = new HashSet<>();
-    Set<UUID> orderableIds = new HashSet<>();
-    collectEventAndOrderableIds(lineItems, eventIds, orderableIds);
-    if (eventIds.isEmpty()) {
-      return;
-    }
-    Map<LineKey, UUID> originLineIdByKey = originLineIdsByKey(eventIds, orderableIds);
-    Map<UUID, StockEvent> cancellationByOriginLine =
-        cancellationEventsByOriginLine(originLineIdByKey.values());
+    Set<UUID> lineItemIds = new HashSet<>();
     for (StockCardLineItemDto dto : lineItems) {
-      setReversedBy(dto, originLineIdByKey, cancellationByOriginLine);
-    }
-  }
-
-  private void collectEventAndOrderableIds(List<StockCardLineItemDto> lineItems,
-      Set<UUID> eventIds, Set<UUID> orderableIds) {
-    for (StockCardLineItemDto dto : lineItems) {
-      LineKey key = LineKey.of(dto);
-      if (key != null) {
-        eventIds.add(key.getEventId());
-        orderableIds.add(key.getOrderableId());
+      if (dto.getStockEventLineItemId() != null) {
+        lineItemIds.add(dto.getStockEventLineItemId());
       }
     }
-  }
-
-  // (event, orderable, lot) -> original line id
-  private Map<LineKey, UUID> originLineIdsByKey(Set<UUID> eventIds, Set<UUID> orderableIds) {
-    Map<LineKey, UUID> map = new HashMap<>();
-    for (StockEventLineItem line : stockEventLineItemRepository
-        .findByStockEventIdInAndOrderableIdIn(eventIds, orderableIds)) {
-      map.putIfAbsent(
-          new LineKey(line.getStockEvent().getId(), line.getOrderableId(), line.getLotId()),
-          line.getId());
+    if (lineItemIds.isEmpty()) {
+      return;
     }
-    return map;
+    Map<UUID, StockEvent> cancellationByOriginLine = cancellationEventsByOriginLine(lineItemIds);
+    for (StockCardLineItemDto dto : lineItems) {
+      StockEvent cancellation = cancellationByOriginLine.get(dto.getStockEventLineItemId());
+      if (cancellation != null) {
+        dto.setCancellationEventId(cancellation.getId());
+        dto.setCancellationEventDocumentNumber(cancellation.getDocumentNumber());
+      }
+    }
   }
 
   // original line id -> the cancellation event that reverses it
@@ -121,19 +103,6 @@ public class CancellationLinkResolver {
           cancellationLine.getStockEvent());
     }
     return map;
-  }
-
-  private void setReversedBy(StockCardLineItemDto dto, Map<LineKey, UUID> originLineIdByKey,
-      Map<UUID, StockEvent> cancellationByOriginLine) {
-    LineKey key = LineKey.of(dto);
-    if (key == null) {
-      return;
-    }
-    StockEvent cancellation = cancellationByOriginLine.get(originLineIdByKey.get(key));
-    if (cancellation != null) {
-      dto.setCancellationEventId(cancellation.getId());
-      dto.setCancellationEventDocumentNumber(cancellation.getDocumentNumber());
-    }
   }
 
   private Map<UUID, StockEvent> reversedEvents(List<StockCardLineItemDto> lineItems) {
@@ -171,26 +140,5 @@ public class CancellationLinkResolver {
 
   private static StockEvent originEventOf(StockCardLineItemDto dto) {
     return dto.getLineItem() == null ? null : dto.getLineItem().getOriginEvent();
-  }
-
-  // Identifies a shown line by (origin event, orderable, lot): the tuple that matches a stock
-  // card line item to its stock event line item. A value object (not a stringly-typed key) so a
-  // null lot compares as an absent value rather than the literal text "null".
-  @Value
-  private static class LineKey {
-    UUID eventId;
-    UUID orderableId;
-    UUID lotId;
-
-    // The key of a shown line, or null when the origin event / owning card is unavailable.
-    static LineKey of(StockCardLineItemDto dto) {
-      StockEvent originEvent = originEventOf(dto);
-      if (originEvent == null || dto.getLineItem().getStockCard() == null) {
-        return null;
-      }
-      return new LineKey(originEvent.getId(),
-          dto.getLineItem().getStockCard().getOrderableId(),
-          dto.getLineItem().getStockCard().getLotId());
-    }
   }
 }

--- a/src/main/java/org/openlmis/stockmanagement/service/StockCardBaseService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockCardBaseService.java
@@ -56,6 +56,9 @@ public abstract class StockCardBaseService {
   @Autowired
   protected CalculatedStockOnHandService calculatedStockOnHandService;
 
+  @Autowired
+  private CancellationLinkResolver cancellationLinkResolver;
+
   protected List<StockCardDto> createDtos(List<StockCard> stockCards) {
     if (stockCards.isEmpty()) {
       return emptyList();
@@ -68,9 +71,16 @@ public abstract class StockCardBaseService {
     LOGGER.debug("Calling ref data to retrieve program info for card");
     ProgramDto program = programRefDataService.findOne(firstCard.getProgramId());
 
-    return stockCards.stream()
+    List<StockCardDto> dtos = stockCards.stream()
         .map(card -> cardToDto(facility, program, card))
         .collect(toList());
+
+    cancellationLinkResolver.attachCancellationLinks(dtos.stream()
+        .filter(dto -> dto.getLineItems() != null)
+        .flatMap(dto -> dto.getLineItems().stream())
+        .collect(toList()));
+
+    return dtos;
   }
 
   private StockCardDto cardToDto(FacilityDto facility, ProgramDto program,

--- a/src/main/java/org/openlmis/stockmanagement/service/StockCardBaseService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockCardBaseService.java
@@ -60,6 +60,13 @@ public abstract class StockCardBaseService {
   private CancellationLinkResolver cancellationLinkResolver;
 
   protected List<StockCardDto> createDtos(List<StockCard> stockCards) {
+    return createDtos(stockCards, true);
+  }
+
+  // withCancellationLinks lets callers that discard the line items right after (the stock card
+  // summaries paths) skip cross-link resolution and its extra per-page queries.
+  protected List<StockCardDto> createDtos(List<StockCard> stockCards,
+      boolean withCancellationLinks) {
     if (stockCards.isEmpty()) {
       return emptyList();
     }
@@ -75,10 +82,12 @@ public abstract class StockCardBaseService {
         .map(card -> cardToDto(facility, program, card))
         .collect(toList());
 
-    cancellationLinkResolver.attachCancellationLinks(dtos.stream()
-        .filter(dto -> dto.getLineItems() != null)
-        .flatMap(dto -> dto.getLineItems().stream())
-        .collect(toList()));
+    if (withCancellationLinks) {
+      cancellationLinkResolver.attachCancellationLinks(dtos.stream()
+          .filter(dto -> dto.getLineItems() != null)
+          .flatMap(dto -> dto.getLineItems().stream())
+          .collect(toList()));
+    }
 
     return dtos;
   }

--- a/src/main/java/org/openlmis/stockmanagement/service/StockCardSummariesService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockCardSummariesService.java
@@ -265,7 +265,7 @@ public class StockCardSummariesService extends StockCardBaseService {
     List<StockCard> dummyCards = createDummyCards(programId, facilityId,
         orderableLotMap.values(),
         existingCardIdentities).collect(toList());
-    return loadOrderableLotUnitAndRemoveLineItems(createDtos(dummyCards), orderableLotMap);
+    return loadOrderableLotUnitAndRemoveLineItems(createDtos(dummyCards, false), orderableLotMap);
   }
 
   private List<StockCardDto> cardsToDtos(List<StockCard> cards) {
@@ -281,7 +281,7 @@ public class StockCardSummariesService extends StockCardBaseService {
         orderableLotsMapIds.stream().map(OrderableLotIdentity::getLotId).filter(Objects::nonNull)
             .collect(toSet())).stream().collect(toMap(LotDto::getId, identity()));
 
-    return createDtos(cards).stream().map(cardDto -> {
+    return createDtos(cards, false).stream().map(cardDto -> {
       cardDto.setOrderable(orderables.get(cardDto.getOrderableId()));
       cardDto.setLot(cardDto.getLotId() != null ? lots.get(cardDto.getLotId()) : null);
       cardDto.setLineItems(null);

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
@@ -18,6 +18,7 @@ package org.openlmis.stockmanagement.service;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_DUPLICATE;
+import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_MISSING_ID;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_STOCK_EVENT_NOT_FOUND;
 
 import java.time.LocalDate;
@@ -83,9 +84,15 @@ public class StockEventCancelService {
   private Map<UUID, StockEventCancelLineItemDto> indexByLineItemId(StockEventCancelDto request) {
     Map<UUID, StockEventCancelLineItemDto> byId = new LinkedHashMap<>();
     for (StockEventCancelLineItemDto line : request.getLineItems()) {
-      if (byId.putIfAbsent(line.getStockEventLineItemId(), line) != null) {
+      UUID lineItemId = line.getStockEventLineItemId();
+      if (lineItemId == null) {
+        // A movement recorded before the reversal feature has no stable line item id, so it
+        // cannot be targeted for cancellation; reject it explicitly rather than fail later.
+        throw new ValidationMessageException(new Message(ERROR_EVENT_LINE_ITEM_MISSING_ID));
+      }
+      if (byId.putIfAbsent(lineItemId, line) != null) {
         throw new ValidationMessageException(
-            new Message(ERROR_EVENT_LINE_ITEM_DUPLICATE, line.getStockEventLineItemId()));
+            new Message(ERROR_EVENT_LINE_ITEM_DUPLICATE, lineItemId));
       }
     }
     return byId;

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventProcessor.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventProcessor.java
@@ -18,14 +18,17 @@ package org.openlmis.stockmanagement.service;
 import static org.openlmis.stockmanagement.dto.PhysicalInventoryDto.fromEventDto;
 
 import java.sql.PreparedStatement;
+import java.util.List;
 import java.util.UUID;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
 import org.openlmis.stockmanagement.domain.event.StockEvent;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
 import org.openlmis.stockmanagement.dto.PhysicalInventoryDto;
 import org.openlmis.stockmanagement.dto.StockEventDto;
+import org.openlmis.stockmanagement.dto.StockEventLineItemDto;
 import org.openlmis.stockmanagement.extension.ExtensionManager;
 import org.openlmis.stockmanagement.extension.point.ExtensionPointId;
 import org.openlmis.stockmanagement.extension.point.StockEventPostProcessor;
@@ -134,8 +137,14 @@ public class StockEventProcessor {
     StockEvent stockEvent = eventDto.toEvent();
 
     profiler.start("DB_SAVE");
-    UUID savedEventId = stockEventsRepository.save(stockEvent).getId();
+    StockEvent savedEvent = stockEventsRepository.save(stockEvent);
+    UUID savedEventId = savedEvent.getId();
     LOGGER.debug("Saved stock event with id " + savedEventId);
+
+    // The persisted line items now have ids; copy them back onto the request dto in the order
+    // toEvent() created them (before sortEventDtos reorders it), so each generated stock card line
+    // item can record the stock event line item it originates from.
+    copyPersistedLineItemIds(eventDto, savedEvent);
 
     if (eventDto.isPhysicalInventory()) {
       profiler.start("CREATE_PHYSICAL_INVENTORY_DTO");
@@ -158,6 +167,19 @@ public class StockEventProcessor {
 
   private void sortEventDtos(StockEventDto eventDto) {
     eventDto.sortLineItemsByOccurreddate();
+  }
+
+  // toEvent() maps request line items to domain line items 1:1 in order, so after save the two
+  // lists line up by index (this runs before sortEventDtos reorders the request dto).
+  private void copyPersistedLineItemIds(StockEventDto eventDto, StockEvent savedEvent) {
+    List<StockEventLineItemDto> requestLines = eventDto.getLineItems();
+    List<StockEventLineItem> savedLines = savedEvent.getLineItems();
+    if (requestLines == null || savedLines == null || requestLines.size() != savedLines.size()) {
+      return;
+    }
+    for (int i = 0; i < requestLines.size(); i++) {
+      requestLines.get(i).setId(savedLines.get(i).getId());
+    }
   }
 
   private void assignDocumentNumberIfNeeded(StockEventDto eventDto) {

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventProcessor.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventProcessor.java
@@ -175,6 +175,13 @@ public class StockEventProcessor {
     List<StockEventLineItemDto> requestLines = eventDto.getLineItems();
     List<StockEventLineItem> savedLines = savedEvent.getLineItems();
     if (requestLines == null || savedLines == null || requestLines.size() != savedLines.size()) {
+      LOGGER.error(
+          "Could not copy persisted line item ids for stock event {}: request line count {} does "
+              + "not match persisted line count {}; generated stock card line items will have no "
+              + "origin line reference and the movement will not be cancellable",
+          savedEvent.getId(),
+          requestLines == null ? null : requestLines.size(),
+          savedLines == null ? null : savedLines.size());
       return;
     }
     for (int i = 0; i < requestLines.size(); i++) {

--- a/src/main/resources/db/migration/20260730120000000__add_origin_event_line_item_to_stock_card_line_items.sql
+++ b/src/main/resources/db/migration/20260730120000000__add_origin_event_line_item_to_stock_card_line_items.sql
@@ -1,0 +1,10 @@
+-- Record, on each stock card line item, the stock event line item it was created from.
+-- This gives reads a stable, unique stockEventLineItemId - needed to cancel a specific line
+-- (partial cancellation) and to resolve the cancellation cross-links reliably, instead of a
+-- non-unique (event, orderable, lot) match. Nullable; populated for rows created going forward.
+ALTER TABLE stockmanagement.stock_card_line_items
+    ADD COLUMN origineventlineitemid UUID;
+
+ALTER TABLE stockmanagement.stock_card_line_items
+    ADD FOREIGN KEY (origineventlineitemid)
+    REFERENCES stockmanagement.stock_event_line_items (id);

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -46,6 +46,7 @@ stockmanagement.error.event.stockOnHand.exceed.upperLimit={0} plus {1} will make
 stockmanagement.error.event.cancellation.validationFailed=One or more line items cannot be cancelled. See the line item errors for details.
 stockmanagement.error.event.cancellation.concurrentModification=The stock data has changed since it was loaded. Please refresh and review the data before cancelling again.
 stockmanagement.error.event.lineItem.notFound=Line item {0} does not belong to stock event {1}.
+stockmanagement.error.event.lineItem.missingId=A selected movement has no stable line item identifier and cannot be cancelled. Movements recorded before the reversal feature was introduced are not cancellable.
 stockmanagement.error.event.lineItem.duplicate=Line item {0} is selected more than once for cancellation.
 stockmanagement.error.event.lineItem.notCancellable=Only issue or receive line items can be cancelled.
 stockmanagement.error.event.lineItem.alreadyCancelled=This line item has already been cancelled.

--- a/src/test/java/org/openlmis/stockmanagement/service/CancellationLinkResolverTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/CancellationLinkResolverTest.java
@@ -28,7 +28,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.openlmis.stockmanagement.domain.card.StockCard;
 import org.openlmis.stockmanagement.domain.card.StockCardLineItem;
 import org.openlmis.stockmanagement.domain.event.StockEvent;
 import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
@@ -66,16 +65,12 @@ public class CancellationLinkResolverTest {
 
   @Test
   public void shouldAttachReversedByLinkForCancelledOriginLine() {
-    UUID orderableId = UUID.randomUUID();
     StockEvent originEvent = event("DOC-ORIGIN");
-    StockEventLineItem originLine = line(originEvent, null);
-    originLine.setOrderableId(orderableId);
+    UUID originLineId = UUID.randomUUID();
     StockEvent cancellationEvent = event("DOC-CANCEL");
-    StockEventLineItem cancellationLine = line(cancellationEvent, originLine.getId());
-    StockCardLineItemDto dto = originDto(originEvent, orderableId);
+    StockEventLineItem cancellationLine = line(cancellationEvent, originLineId);
+    StockCardLineItemDto dto = originDto(originEvent, originLineId);
 
-    when(stockEventLineItemRepository.findByStockEventIdInAndOrderableIdIn(any(), any()))
-        .thenReturn(singletonList(originLine));
     when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(any()))
         .thenReturn(singletonList(cancellationLine));
 
@@ -118,10 +113,11 @@ public class CancellationLinkResolverTest {
     return StockCardLineItemDto.builder().lineItem(cardLine).build();
   }
 
-  private StockCardLineItemDto originDto(StockEvent originEvent, UUID orderableId) {
-    StockCard card = StockCard.builder().orderableId(orderableId).build();
-    StockCardLineItem cardLine = StockCardLineItem.builder()
-        .originEvent(originEvent).stockCard(card).build();
-    return StockCardLineItemDto.builder().lineItem(cardLine).build();
+  private StockCardLineItemDto originDto(StockEvent originEvent, UUID stockEventLineItemId) {
+    StockCardLineItem cardLine = StockCardLineItem.builder().originEvent(originEvent).build();
+    return StockCardLineItemDto.builder()
+        .lineItem(cardLine)
+        .stockEventLineItemId(stockEventLineItemId)
+        .build();
   }
 }

--- a/src/test/java/org/openlmis/stockmanagement/service/CancellationLinkResolverTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/CancellationLinkResolverTest.java
@@ -1,0 +1,127 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.stockmanagement.service;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openlmis.stockmanagement.domain.card.StockCard;
+import org.openlmis.stockmanagement.domain.card.StockCardLineItem;
+import org.openlmis.stockmanagement.domain.event.StockEvent;
+import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
+import org.openlmis.stockmanagement.dto.StockCardLineItemDto;
+import org.openlmis.stockmanagement.repository.StockEventLineItemRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CancellationLinkResolverTest {
+
+  @Mock
+  private StockEventLineItemRepository stockEventLineItemRepository;
+
+  @InjectMocks
+  private CancellationLinkResolver resolver;
+
+  @Test
+  public void shouldAttachReversingLinkForCancellationLine() {
+    StockEvent originEvent = event("DOC-ORIGIN");
+    StockEventLineItem originLine = line(originEvent, null);
+    StockEvent cancellationEvent = event("DOC-CANCEL");
+    StockEventLineItem cancellationLine = line(cancellationEvent, originLine.getId());
+    StockCardLineItemDto dto = cancellationDto(cancellationEvent);
+
+    when(stockEventLineItemRepository
+        .findByStockEventIdInAndReversesEventLineItemIdIsNotNull(any()))
+        .thenReturn(singletonList(cancellationLine));
+    when(stockEventLineItemRepository.findAllById(any()))
+        .thenReturn(singletonList(originLine));
+
+    resolver.attachCancellationLinks(singletonList(dto));
+
+    assertEquals(originEvent.getId(), dto.getReversedEventId());
+    assertEquals("DOC-ORIGIN", dto.getReversedEventDocumentNumber());
+  }
+
+  @Test
+  public void shouldAttachReversedByLinkForCancelledOriginLine() {
+    UUID orderableId = UUID.randomUUID();
+    StockEvent originEvent = event("DOC-ORIGIN");
+    StockEventLineItem originLine = line(originEvent, null);
+    originLine.setOrderableId(orderableId);
+    StockEvent cancellationEvent = event("DOC-CANCEL");
+    StockEventLineItem cancellationLine = line(cancellationEvent, originLine.getId());
+    StockCardLineItemDto dto = originDto(originEvent, orderableId);
+
+    when(stockEventLineItemRepository.findByStockEventIdInAndOrderableIdIn(any(), any()))
+        .thenReturn(singletonList(originLine));
+    when(stockEventLineItemRepository.findByReversesEventLineItemIdIn(any()))
+        .thenReturn(singletonList(cancellationLine));
+
+    resolver.attachCancellationLinks(singletonList(dto));
+
+    assertEquals(cancellationEvent.getId(), dto.getCancellationEventId());
+    assertEquals("DOC-CANCEL", dto.getCancellationEventDocumentNumber());
+  }
+
+  @Test
+  public void shouldNotAttachWhenEventIsNotCancellation() {
+    StockCardLineItemDto dto = cancellationDto(event("DOC-1"));
+    when(stockEventLineItemRepository
+        .findByStockEventIdInAndReversesEventLineItemIdIsNotNull(any()))
+        .thenReturn(emptyList());
+
+    resolver.attachCancellationLinks(singletonList(dto));
+
+    assertNull(dto.getReversedEventId());
+    assertNull(dto.getCancellationEventId());
+  }
+
+  private StockEvent event(String documentNumber) {
+    StockEvent event = new StockEvent();
+    event.setId(UUID.randomUUID());
+    event.setDocumentNumber(documentNumber);
+    return event;
+  }
+
+  private StockEventLineItem line(StockEvent stockEvent, UUID reversesEventLineItemId) {
+    StockEventLineItem line = new StockEventLineItem();
+    line.setId(UUID.randomUUID());
+    line.setStockEvent(stockEvent);
+    line.setReversesEventLineItemId(reversesEventLineItemId);
+    return line;
+  }
+
+  private StockCardLineItemDto cancellationDto(StockEvent originEvent) {
+    StockCardLineItem cardLine = StockCardLineItem.builder().originEvent(originEvent).build();
+    return StockCardLineItemDto.builder().lineItem(cardLine).build();
+  }
+
+  private StockCardLineItemDto originDto(StockEvent originEvent, UUID orderableId) {
+    StockCard card = StockCard.builder().orderableId(orderableId).build();
+    StockCardLineItem cardLine = StockCardLineItem.builder()
+        .originEvent(originEvent).stockCard(card).build();
+    return StockCardLineItemDto.builder().lineItem(cardLine).build();
+  }
+}

--- a/src/test/java/org/openlmis/stockmanagement/service/StockCardServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockCardServiceTest.java
@@ -85,6 +85,11 @@ public class StockCardServiceTest {
   @Mock
   private PermissionService permissionService;
 
+  @Mock
+  // injected into StockCardBaseService via @InjectMocks; not referenced directly in this test
+  @SuppressWarnings("PMD.UnusedPrivateField")
+  private CancellationLinkResolver cancellationLinkResolver;
+
   @InjectMocks
   private StockCardService stockCardService;
 

--- a/src/test/java/org/openlmis/stockmanagement/service/StockCardSummariesServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockCardSummariesServiceTest.java
@@ -130,6 +130,11 @@ public class StockCardSummariesServiceTest {
   private CalculatedStockOnHandRepository calculatedStockOnHandRepository;
   @Mock
   private HomeFacilityPermissionService homeFacilityPermissionService;
+  @Mock
+  // injected into StockCardBaseService via @InjectMocks; not referenced directly in this test
+  @SuppressWarnings("PMD.UnusedPrivateField")
+  private CancellationLinkResolver cancellationLinkResolver;
+
   @InjectMocks
   private StockCardSummariesService stockCardSummariesService;
 

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
@@ -132,6 +132,15 @@ public class StockEventCancelServiceTest {
     service.cancel(eventId, new StockEventCancelDto("signature", asList(first, duplicate)));
   }
 
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowWhenLineItemHasNoStableId() {
+    StockEvent event = eventWithIssueLine();
+    when(stockEventsRepository.findById(eventId)).thenReturn(Optional.of(event));
+
+    // A movement recorded before the reversal feature exposes a null stockEventLineItemId.
+    service.cancel(eventId, requestFor(null, UUID.randomUUID()));
+  }
+
   @Test(expected = PermissionMessageException.class)
   public void shouldThrowWhenUserHasNoCancelPermission() {
     StockEvent event = eventWithIssueLine();

--- a/src/test/java/org/openlmis/stockmanagement/testutils/StockCardLineItemDataBuilder.java
+++ b/src/test/java/org/openlmis/stockmanagement/testutils/StockCardLineItemDataBuilder.java
@@ -166,7 +166,7 @@ public class StockCardLineItemDataBuilder {
     StockCardLineItem lineItem = new StockCardLineItem(
         stockCard, originEvent, quantity, extraData, reason, sourceFreeText, destinationFreeText,
         documentNumber, reasonFreeText, signature, source, destination, occurredDate,
-        processedDateTime, userId, stockOnHand, username, stockAdjustments
+        processedDateTime, userId, null, stockOnHand, username, stockAdjustments
     );
     lineItem.setId(id);
 

--- a/src/test/java/org/openlmis/stockmanagement/testutils/StockEventLineItemDtoDataBuilder.java
+++ b/src/test/java/org/openlmis/stockmanagement/testutils/StockEventLineItemDtoDataBuilder.java
@@ -57,8 +57,8 @@ public class StockEventLineItemDtoDataBuilder {
    */
   public StockEventLineItemDto buildForAdjustment() {
     noSourceAndDestination();
-    return new StockEventLineItemDto(orderableId, lotId,quantity, extraData, occurredDate, reasonId,
-        reasonFreeText, sourceId, sourceFreeText, destinationId, destinationFreeText,
+    return new StockEventLineItemDto(null, orderableId, lotId, quantity, extraData, occurredDate,
+        reasonId, reasonFreeText, sourceId, sourceFreeText, destinationId, destinationFreeText,
         reversesEventLineItemId, stockAdjustments);
   }
 
@@ -66,8 +66,8 @@ public class StockEventLineItemDtoDataBuilder {
    * Build new Stock Event.
    */
   public StockEventLineItemDto build() {
-    return new StockEventLineItemDto(orderableId, lotId,quantity, extraData, occurredDate, reasonId,
-        reasonFreeText, sourceId, sourceFreeText, destinationId, destinationFreeText,
+    return new StockEventLineItemDto(null, orderableId, lotId, quantity, extraData, occurredDate,
+        reasonId, reasonFreeText, sourceId, sourceFreeText, destinationId, destinationFreeText,
         reversesEventLineItemId, stockAdjustments);
   }
 


### PR DESCRIPTION
## Summary

Resolves, read-side only, the cross-links between an issue/receive stock event and the
event that cancelled it (SELV3-861, Scenario 2 — the original event is left untouched).
Feeds the two UI columns added in SELV3-860:

- **Reversing** — a cancellation line → the original event it reverses.
- **Reversed by** — an original line → the cancellation event that reversed it.

## Stacking

Based on `SELV3-858-cancel-endpoint` (the cancel endpoint this builds on), so the diff is
only the SELV3-861 change (4 commits, 16 files). Please merge the SELV3-858 PR first; this
PR will retarget to `master` automatically.

## What changed

- **Read DTOs** — `StockCardLineItemDto` and `StockEventLineDetailDto` gain nullable read
  fields: the cross-links `reversedEventId` / `reversedEventDocumentNumber` and
  `cancellationEventId` / `cancellationEventDocumentNumber`, plus a stable
  `stockEventLineItemId` — the id of the stock event line item each row was created from.
- **Stable line id (write path)** — `StockCardLineItem` gains an `origineventlineitemid`
  column (migration), set during processing from the persisted stock event line item
  (`StockEventProcessor` copies the ids back onto the request after save, before the line
  items are re-sorted). Reads get a stable, unique per-line identifier — used both to cancel
  a specific line and as the "Reversed by" key below.
- **CancellationLinkResolver** (new) — resolves both directions in batch (a fixed number of
  queries per page, not per row):
    - *Reversing*: cancellation line → `reversesEventLineItemId` → origin line → origin event
      (once per cancellation event).
    - *Reversed by*: keyed by each row's stable `stockEventLineItemId` via the indexed
      `findByReversesEventLineItemIdIn`, so a partial cancellation marks only the cancelled
      line — correct even when one event has two lines for the same orderable + lot.
- **Wiring** — invoked in `StockCardBaseService.createDtos` (the single enrichment point for
  both reads, `GET /api/stockCards/{id}` and `GET /api/stockEvents/{id}/lineItems`), gated by
  a flag so the stock card summaries paths — which discard the line items immediately — skip it.
- **Repository** — one new derived query (`findByStockEventIdInAndReversesEventLineItemIdIsNotNull`);
  the "Reversed by" lookup reuses `findByReversesEventLineItemIdIn` from 858.

## Performance (the denormalization gate)

Resolve-on-read (Scenario 2) is kept. On ref-distro: sub-second on a 111-line card
(`/stockCards/{id}` ~0.5 s, `/stockEvents/{id}/lineItems` ~1 s), bounded query count per page.
The forward-reference denormalization (Scenario 3) is still **not** built; the only stored
addition is the per-line `origineventlineitemid`, needed for correct line identity — not a perf
optimization.

## Testing

- Unit `CancellationLinkResolverTest` (Reversing / Reversed by / no-link).
- Integration `StockEventProcessorIntegrationTest` — asserts the generated stock card line item
  records its origin stock event line item id.
- `gradle clean build` green (unit + integrationTest + checkstyle + PMD + RAML).
- E2E on ref-distro: cancelled one receive line → verified both directions on both reads,
  per-line correctness, sub-second.

## Notes for reviewers

- "Reversed by" is resolved per line by the stable `stockEventLineItemId`, so it stays accurate
  even when one event has two line items for the same orderable + lot.
- Cancellation events carry no document number, so the linked document-number field can be
  null — the UI falls back to a "View" label (handled in the SELV3-860 frontend PR).
