### PR TITLE
OLMIS-8280: Pass sonar.projectVersion to the SonarCloud analysis

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -25,9 +25,14 @@ jobs:
           docker compose -f docker-compose.builder.yml run builder
           sudo chown -R $(whoami) ./
           cp ./build/reports/jacoco/test/jacocoTestReport.xml report.xml
+      - name: Resolve service version
+        id: version
+        run: echo "value=$(grep -E '^serviceVersion=' gradle.properties | cut -d= -f2)" >> "$GITHUB_OUTPUT"
       - name: Analyze
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
+        with:
+          args: -Dsonar.projectVersion=${{ steps.version.outputs.value }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Upcoming Version (WIP)
 * [SELV3-849](https://openlmis.atlassian.net/browse/SELV3-849) Unified StockCardLineItem ordering on retrieval
 * [SELV3-842](https://openlmis.atlassian.net/browse/SELV3-842) Added `GET /api/stockEvents/{id}` endpoint
 * [SELV3-841](https://openlmis.atlassian.net/browse/SELV3-841) Added `GET /api/stockEvents/{id}/print` endpoint for generating PDF report for stock event transactions
-* Fixed SonarCloud analysis failing on the deprecated Java 17 runtime by running it through the SonarQube scan action (on Java 21) instead of the Gradle plugin, and removed the now-unused Gradle sonar plugin and configuration.
-* Removed the axios dependency from the Consul registration script, replacing it with the native Node `http` client (no more axios security advisories to track).
+* [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Fixed SonarCloud analysis failing on the deprecated Java 17 runtime by running it through the SonarQube scan action (on Java 21) instead of the Gradle plugin, and removed the now-unused Gradle sonar plugin and configuration.
+* [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Removed the axios dependency from the Consul registration script, replacing it with the native Node `http` client (no more axios security advisories to track).
+* [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Passed sonar.projectVersion (from the service version) to the SonarCloud analysis so New Code (Previous version) coverage is tracked correctly on master — completing the Java 21 migration.
 
 5.3.1 / 2026-06-09
 ==================


### PR DESCRIPTION
Follow-up to #107, which migrated the SonarCloud analysis to Java 21 via `SonarSource/sonarqube-scan-action`.

#107 replaced the `org.sonarqube` Gradle plugin, which used to set `sonar.projectVersion` automatically from the build (`serviceVersion`). The standalone scanner does not, so the version stopped being reported. Because this project's SonarCloud **New Code** is defined as **"Previous version"**, the analysis needs that version to attribute new-code coverage correctly on `master`.

## What
- Add a step that reads `serviceVersion` from `gradle.properties`
- Pass `-Dsonar.projectVersion` to `sonarqube-scan-action` — matching every other backend repo migrated under OLMIS-8280

No other changes; build, tests and coverage are unaffected.
