### PR TITLE
[SELV3-856] Reverse transaction QA changes

### DIFF
--- a/src/integration-test/java/org/openlmis/stockmanagement/web/StockEventsHistoryControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/stockmanagement/web/StockEventsHistoryControllerIntegrationTest.java
@@ -142,7 +142,7 @@ public class StockEventsHistoryControllerIntegrationTest extends BaseWebTest {
     verify(stockEventsService).search(captor.capture(), any(Pageable.class));
 
     assertThat(captor.getValue().getEventOrigins(),
-        containsInAnyOrder(EventOrigin.ISSUE, EventOrigin.RECEIVE));
+        containsInAnyOrder(EventOrigin.ISSUE, EventOrigin.RECEIVE, EventOrigin.ADJUSTMENT));
   }
 
   @Test

--- a/src/main/java/org/openlmis/stockmanagement/domain/event/EventOrigin.java
+++ b/src/main/java/org/openlmis/stockmanagement/domain/event/EventOrigin.java
@@ -17,5 +17,6 @@ package org.openlmis.stockmanagement.domain.event;
 
 public enum EventOrigin {
   ISSUE,
-  RECEIVE
+  RECEIVE,
+  ADJUSTMENT
 }

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelService.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.openlmis.stockmanagement.domain.event.EventOrigin;
 import org.openlmis.stockmanagement.domain.event.StockEvent;
 import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
 import org.openlmis.stockmanagement.domain.reason.StockCardLineItemReason;
@@ -125,6 +126,8 @@ public class StockEventCancelService {
     cancellation.setProgramId(event.getProgramId());
     cancellation.setSignature(signature);
     cancellation.setActive(true);
+    // So the reversal is listed in the transaction history and gets a document number.
+    cancellation.setEventOrigin(EventOrigin.ADJUSTMENT);
     cancellation.setLineItems(lineItems);
     return cancellation;
   }

--- a/src/main/java/org/openlmis/stockmanagement/web/StockEventsController.java
+++ b/src/main/java/org/openlmis/stockmanagement/web/StockEventsController.java
@@ -148,9 +148,9 @@ public class StockEventsController extends BaseController {
     return stockEventsService.search(params, pageable);
   }
 
-  // "all"/blank means issue and receive only; new origins are not auto-included.
+  // "all"/blank means issues, receives and the adjustments that reverse them.
   private static final Collection<EventOrigin> ALL_HISTORY_ORIGINS =
-      Arrays.asList(EventOrigin.ISSUE, EventOrigin.RECEIVE);
+      Arrays.asList(EventOrigin.ISSUE, EventOrigin.RECEIVE, EventOrigin.ADJUSTMENT);
 
   private Collection<EventOrigin> toEventOrigins(String type) {
     if (StringUtils.isBlank(type) || "all".equalsIgnoreCase(type)) {

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelServiceTest.java
@@ -39,6 +39,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.openlmis.stockmanagement.domain.event.EventOrigin;
 import org.openlmis.stockmanagement.domain.event.StockEvent;
 import org.openlmis.stockmanagement.domain.event.StockEventLineItem;
 import org.openlmis.stockmanagement.domain.reason.ReasonCategory;
@@ -101,6 +102,7 @@ public class StockEventCancelServiceTest {
     assertEquals(programId, cancellation.getProgramId());
     assertEquals("signature", cancellation.getSignature());
     assertTrue(cancellation.isActive());
+    assertEquals(EventOrigin.ADJUSTMENT, cancellation.getEventOrigin());
     StockEventLineItemDto line = cancellation.getLineItems().get(0);
     assertEquals(original.getId(), line.getReversesEventLineItemId());
     assertEquals(reason.getId(), line.getReasonId());


### PR DESCRIPTION
Task:
https://openlmis.atlassian.net/browse/SELV3-856
Description:
Reversals were missing from the list and had an empty Type in the header, because
cancellation events were created with `eventOrigin = null`.

- `EventOrigin` - new `ADJUSTMENT` value
- `StockEventCancelService` - sets it on the cancellation event
- `StockEventsController` - `ALL_HISTORY_ORIGINS` includes `ADJUSTMENT`