### PR TITLE
[SELV3-869] Remove cancel tag

### DIFF
--- a/src/main/java/org/openlmis/stockmanagement/service/CancellationReasonResolver.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/CancellationReasonResolver.java
@@ -24,7 +24,7 @@ import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLA
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_VALIDATION;
 import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_ADJUSTMENT_TAG;
 import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_MOVEMENT_TAG;
-import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_TAG;
+import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.isCancelReason;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -113,7 +113,7 @@ public class CancellationReasonResolver {
     StockCardLineItemReason reason = reasonsById.get(reasonId);
     if (reason == null
         || !reason.isAdjustmentReasonCategory()
-        || !reason.getTags().contains(CANCEL_TAG)
+        || !isCancelReason(reason)
         || !counters(original, reason, reasonsById)) {
       errors.add(lineError(requested, ERROR_EVENT_CANCELLATION_REASON_INVALID));
       return null;

--- a/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
+++ b/src/main/java/org/openlmis/stockmanagement/service/StockEventCancelValidationService.java
@@ -61,9 +61,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StockEventCancelValidationService {
 
-  static final String CANCEL_TAG = "cancel";
   static final String CANCEL_MOVEMENT_TAG = "cancelMovement";
   static final String CANCEL_ADJUSTMENT_TAG = "cancelAdjustment";
+  // Add a new cancel scope here and every "is this a cancel reason" check picks it up.
+  private static final List<String> CANCEL_TAGS =
+      asList(CANCEL_MOVEMENT_TAG, CANCEL_ADJUSTMENT_TAG);
   static final String PHYSICAL_INVENTORY_TYPE = "PHYSICAL_INVENTORY";
 
   private final StockEventLineItemRepository stockEventLineItemRepository;
@@ -173,8 +175,11 @@ public class StockEventCancelValidationService {
 
   private boolean isCancellationReason(StockEventLineItem lineItem,
       Map<UUID, StockCardLineItemReason> reasonsById) {
-    StockCardLineItemReason reason = reasonsById.get(lineItem.getReasonId());
-    return reason != null && reason.getTags().contains(CANCEL_TAG);
+    return isCancelReason(reasonsById.get(lineItem.getReasonId()));
+  }
+
+  static boolean isCancelReason(StockCardLineItemReason reason) {
+    return reason != null && reason.getTags().stream().anyMatch(CANCEL_TAGS::contains);
   }
 
   private List<BlockingTransactionDto> findBlockingInventories(StockEvent event,

--- a/src/main/resources/db/migration/20260828113045912__drop_cancel_tag_from_cancel_reasons.sql
+++ b/src/main/resources/db/migration/20260828113045912__drop_cancel_tag_from_cancel_reasons.sql
@@ -1,0 +1,8 @@
+-- The scope tag now identifies a cancellation reason on its own.
+DELETE FROM stockmanagement.stock_card_line_item_reason_tags
+ WHERE tag = 'cancel'
+   AND reasonId IN (
+       '6997c774-2f91-4e36-8938-d3003fe2c203',
+       '46aa9d3e-0ce4-4138-b086-172cefb58360',
+       '0f9a0b4c-2d59-4d3a-9ca1-3c6b8f4d2e71',
+       'c3b6f5a2-8e14-4a77-b0d6-5e2a9c7f1b48');

--- a/src/test/java/org/openlmis/stockmanagement/service/CancellationReasonResolverTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/CancellationReasonResolverTest.java
@@ -27,7 +27,6 @@ import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLA
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_CANCELLATION_REASON_REQUIRED;
 import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_ADJUSTMENT_TAG;
 import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_MOVEMENT_TAG;
-import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_TAG;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -59,7 +58,7 @@ public class CancellationReasonResolverTest {
   @Test
   public void shouldResolveReasonThatCountersIssue() {
     StockEventLineItem issue = issueLineItem();
-    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_TAG, CANCEL_MOVEMENT_TAG);
+    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_MOVEMENT_TAG);
     when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
 
     Map<UUID, StockCardLineItemReason> resolved =
@@ -90,7 +89,7 @@ public class CancellationReasonResolverTest {
   @Test(expected = StockEventCancellationException.class)
   public void shouldThrowWhenReasonTypeDoesNotCounterMovement() {
     StockEventLineItem issue = issueLineItem();
-    StockCardLineItemReason reason = reason(ReasonType.DEBIT, CANCEL_TAG, CANCEL_MOVEMENT_TAG);
+    StockCardLineItemReason reason = reason(ReasonType.DEBIT, CANCEL_MOVEMENT_TAG);
     when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
 
     resolver.resolve(singletonList(requested(issue.getId(), reason.getId())),
@@ -101,7 +100,7 @@ public class CancellationReasonResolverTest {
   public void shouldCollectEveryBadReasonAsAPerLineError() {
     StockEventLineItem missingReason = issueLineItem();
     StockEventLineItem wrongType = issueLineItem();
-    StockCardLineItemReason debit = reason(ReasonType.DEBIT, CANCEL_TAG, CANCEL_MOVEMENT_TAG);
+    StockCardLineItemReason debit = reason(ReasonType.DEBIT, CANCEL_MOVEMENT_TAG);
     when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(debit));
 
     Map<UUID, StockEventLineItem> originals = new HashMap<>();
@@ -130,7 +129,7 @@ public class CancellationReasonResolverTest {
   public void shouldResolveCreditReasonThatCountersDebitAdjustment() {
     StockCardLineItemReason originalReason = reason(ReasonType.DEBIT);
     StockEventLineItem adjustment = adjustmentLineItem(originalReason.getId());
-    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_TAG, CANCEL_ADJUSTMENT_TAG);
+    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_ADJUSTMENT_TAG);
     when(reasonRepository.findByIdIn(anyCollection()))
         .thenReturn(asList(originalReason, reason));
 
@@ -145,7 +144,7 @@ public class CancellationReasonResolverTest {
   public void shouldResolveDebitReasonThatCountersCreditAdjustment() {
     StockCardLineItemReason originalReason = reason(ReasonType.CREDIT);
     StockEventLineItem adjustment = adjustmentLineItem(originalReason.getId());
-    StockCardLineItemReason reason = reason(ReasonType.DEBIT, CANCEL_TAG, CANCEL_ADJUSTMENT_TAG);
+    StockCardLineItemReason reason = reason(ReasonType.DEBIT, CANCEL_ADJUSTMENT_TAG);
     when(reasonRepository.findByIdIn(anyCollection()))
         .thenReturn(asList(originalReason, reason));
 
@@ -160,7 +159,7 @@ public class CancellationReasonResolverTest {
   public void shouldThrowWhenReasonTypeDoesNotCounterAdjustment() {
     StockCardLineItemReason originalReason = reason(ReasonType.DEBIT);
     StockEventLineItem adjustment = adjustmentLineItem(originalReason.getId());
-    StockCardLineItemReason reason = reason(ReasonType.DEBIT, CANCEL_TAG, CANCEL_ADJUSTMENT_TAG);
+    StockCardLineItemReason reason = reason(ReasonType.DEBIT, CANCEL_ADJUSTMENT_TAG);
     when(reasonRepository.findByIdIn(anyCollection()))
         .thenReturn(asList(originalReason, reason));
 
@@ -172,7 +171,7 @@ public class CancellationReasonResolverTest {
   public void shouldThrowWhenMovementReasonIsUsedToCancelAdjustment() {
     StockCardLineItemReason originalReason = reason(ReasonType.DEBIT);
     StockEventLineItem adjustment = adjustmentLineItem(originalReason.getId());
-    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_TAG, CANCEL_MOVEMENT_TAG);
+    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_MOVEMENT_TAG);
     when(reasonRepository.findByIdIn(anyCollection()))
         .thenReturn(asList(originalReason, reason));
 
@@ -183,7 +182,7 @@ public class CancellationReasonResolverTest {
   @Test(expected = StockEventCancellationException.class)
   public void shouldThrowWhenAdjustmentReasonIsUsedToCancelMovement() {
     StockEventLineItem issue = issueLineItem();
-    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_TAG, CANCEL_ADJUSTMENT_TAG);
+    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_ADJUSTMENT_TAG);
     when(reasonRepository.findByIdIn(anyCollection())).thenReturn(singletonList(reason));
 
     resolver.resolve(singletonList(requested(issue.getId(), reason.getId())),
@@ -194,7 +193,7 @@ public class CancellationReasonResolverTest {
   public void shouldThrowWhenOriginalAdjustmentReasonHasNoDirection() {
     StockCardLineItemReason originalReason = reason(ReasonType.BALANCE_ADJUSTMENT);
     StockEventLineItem adjustment = adjustmentLineItem(originalReason.getId());
-    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_TAG, CANCEL_ADJUSTMENT_TAG);
+    StockCardLineItemReason reason = reason(ReasonType.CREDIT, CANCEL_ADJUSTMENT_TAG);
     when(reasonRepository.findByIdIn(anyCollection()))
         .thenReturn(asList(originalReason, reason));
 

--- a/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelValidationServiceTest.java
+++ b/src/test/java/org/openlmis/stockmanagement/service/StockEventCancelValidationServiceTest.java
@@ -28,7 +28,7 @@ import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITE
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_BLOCKED_PHYSICAL_INVENTORY;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_IS_CANCELLATION;
 import static org.openlmis.stockmanagement.i18n.MessageKeys.ERROR_EVENT_LINE_ITEM_NOT_CANCELLABLE;
-import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_TAG;
+import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.CANCEL_MOVEMENT_TAG;
 import static org.openlmis.stockmanagement.service.StockEventCancelValidationService.PHYSICAL_INVENTORY_TYPE;
 
 import java.time.LocalDate;
@@ -339,7 +339,7 @@ public class StockEventCancelValidationServiceTest {
         .name("Cancelled issue")
         .reasonType(ReasonType.CREDIT)
         .reasonCategory(ReasonCategory.ADJUSTMENT)
-        .tags(singletonList(CANCEL_TAG))
+        .tags(singletonList(CANCEL_MOVEMENT_TAG))
         .build();
     reason.setId(id);
     return reason;


### PR DESCRIPTION
Task:
https://openlmis.atlassian.net/browse/SELV3-869
Description:
Drops the redundant cancel tag - a reason is now identified as a cancellation reason by its scope tag alone, via a single `CANCEL_TAGS` list that any future scope is added to once. Migration deletes the four cancel rows